### PR TITLE
Openshift Docker Image

### DIFF
--- a/theia-openshift-docker/Dockerfile
+++ b/theia-openshift-docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM theiaide/theia
+COPY entrypoint /home/theia 
+RUN chgrp -R 0 /home/theia && \
+    chmod a+x /home/theia/entrypoint && \
+    chmod -R g=u /home/theia && \
+    chmod g=u /etc/passwd
+USER 10001
+ENTRYPOINT ["/home/theia/entrypoint"]
+CMD yarn theia start /home/project --hostname 0.0.0.0

--- a/theia-openshift-docker/entrypoint
+++ b/theia-openshift-docker/entrypoint
@@ -1,0 +1,8 @@
+#!/bin/bash 
+export HOME=/home/theia
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+if [ -w /etc/passwd ]; then
+  echo "default:x:$(id -u):$(id -g):default user:${HOME}:/sbin/nologin" >> /etc/passwd
+fi
+exec "$@"


### PR DESCRIPTION
Openshift requires that user not have root user permissions. Openshift defaults to a random user id number that does not have root permissions https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html#openshift-container-platform-specific-guidelines . This means that passwd file needs to be updated to include random user in startup script to ensure applications run correctly. Permissions of certain folders need be changed to be readable and executed by this random user that belongs to the group "root" by default.

Theia team would need to add an Docker image to the automated builds for docker hub which builds after base image 'theiaide/theia' is built. Name needs to pick for this image but could be 'theiaide/theia-openshift'.

Related issue https://github.com/theia-ide/theia/issues/1655

Signed-off-by: James Drummond \<james.m.drummond@gmail.com\>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.