### PR TITLE
upgrade theia-docker images

### DIFF
--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -14,7 +14,9 @@
         "@theia/preview": "latest",
         "@theia/callhierarchy": "latest",
         "@theia/merge-conflicts": "latest",
-        "@theia/search-in-workspace": "latest"
+        "@theia/search-in-workspace": "latest",
+        "@theia/textmate-grammars": "latest",
+        "@theia/mini-browser": "latest"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -14,7 +14,10 @@
         "@theia/preview": "next",
         "@theia/callhierarchy": "next",
         "@theia/merge-conflicts": "next",
-        "@theia/search-in-workspace": "next"
+        "@theia/search-in-workspace": "next",
+        "@theia/json": "next",
+        "@theia/textmate-grammars": "next",
+        "@theia/mini-browser": "next"
     },
     "devDependencies": {
         "@theia/cli": "next"


### PR DESCRIPTION
This PR adds JSON and basic languages highlighting support to theia-docker images. I have not:
- added JSON support to latest, since we publish it only against next;
- changed other images, because I don't want to test them, they can be tackled by other PRs.