### PR TITLE
[full] Remove @theia/ruby from "latest"

### DIFF
--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -30,7 +30,6 @@
         "@theia/preview": "latest",
         "@theia/process": "latest",
         "@theia/python": "latest",
-        "@theia/ruby": "latest",
         "@theia/rust": "latest",
         "@theia/search-in-workspace": "latest",
         "@theia/task": "latest",


### PR DESCRIPTION
This extension is causing issues for "latest", breaking the coloring. We
can add it back after next release.

Fixes #84

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>