### PR TITLE
update golint link

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -87,7 +87,7 @@ RUN go get -u -v github.com/nsf/gocode
 RUN go get -u -v github.com/rogpeppe/godef
 RUN go get -u -v golang.org/x/tools/cmd/godoc
 RUN go get -u -v github.com/zmb3/gogetdoc
-RUN go get -u -v github.com/golang/lint/golint
+RUN go get -u -v golang.org/x/lint/golint
 RUN go get -u -v github.com/fatih/gomodifytags
 RUN go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs
 RUN go get -u -v golang.org/x/tools/cmd/gorename

--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -24,7 +24,7 @@ RUN go get -u -v github.com/ramya-rao-a/go-outline && \
     go get -u -v github.com/rogpeppe/godef && \
     go get -u -v golang.org/x/tools/cmd/godoc && \
     go get -u -v github.com/zmb3/gogetdoc && \
-    go get -u -v github.com/golang/lint/golint && \
+    go get -u -v golang.org/x/lint/golint && \
     go get -u -v github.com/fatih/gomodifytags && \
     go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs && \
     go get -u -v golang.org/x/tools/cmd/gorename && \


### PR DESCRIPTION
The docker build fails due to outdated golint links. 
Reference: [ead987a](https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3)