### PR TITLE
[theia-docker] trim down docker image size

### DIFF
--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -21,6 +21,7 @@ RUN chmod g+rw /home && \
     chown -R theia:theia /home/theia && \
     chown -R theia:theia /home/project;
 RUN apk add --no-cache git openssh bash
+ENV HOME /home/theia
 WORKDIR /home/theia
 COPY --from=0 /home/theia /home/theia
 EXPOSE 3000

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -8,6 +8,9 @@ RUN yarn --pure-lockfile && \
     yarn theia build && \
     yarn --production && \
     yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
     yarn autoclean --force && \
     rm -rf ./node_modules/electron && \
     yarn cache clean

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -19,11 +19,11 @@ RUN addgroup theia && \
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project;
+    chown -R theia:theia /home/project;    
 RUN apk add --no-cache git openssh bash
 ENV HOME /home/theia
 WORKDIR /home/theia
-COPY --from=0 /home/theia /home/theia
+COPY --from=0 --chown=theia:theia /home/theia /home/theia
 EXPOSE 3000
 ENV SHELL /bin/bash
 ENV USE_LOCAL_GIT true

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -28,4 +28,4 @@ EXPOSE 3000
 ENV SHELL /bin/bash
 ENV USE_LOCAL_GIT true
 USER theia
-ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]
+CMD [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -7,6 +7,8 @@ ARG GITHUB_TOKEN
 RUN yarn --pure-lockfile && \
     yarn theia build && \
     yarn --production && \
+    yarn autoclean --init && \
+    yarn autoclean --force && \
     rm -rf ./node_modules/electron && \
     yarn cache clean
 

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -19,7 +19,7 @@ RUN addgroup theia && \
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project;    
+    chown -R theia:theia /home/project;
 RUN apk add --no-cache git openssh bash
 ENV HOME /home/theia
 WORKDIR /home/theia
@@ -28,4 +28,4 @@ EXPOSE 3000
 ENV SHELL /bin/bash
 ENV USE_LOCAL_GIT true
 USER theia
-CMD [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]
+ENTRYPOINT [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -4,19 +4,20 @@ ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
-RUN yarn && \
+RUN yarn --pure-lockfile && \
     yarn theia build && \
+    yarn --production && \
     rm -rf ./node_modules/electron && \
     yarn cache clean
 
 FROM node:8-alpine
 # See : https://github.com/theia-ide/theia-apps/issues/34
-RUN addgroup theia && \ 
+RUN addgroup theia && \
     adduser -G theia -s /bin/sh -D theia;
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project;    
+    chown -R theia:theia /home/project;
 RUN apk add --no-cache git openssh bash
 WORKDIR /home/theia
 COPY --from=0 /home/theia /home/theia


### PR DESCRIPTION
This is in relation to [PR #80](https://github.com/theia-ide/theia-apps/pull/80) as well as additional fixes. Description are on the commits.

Image size is trimmed down to about `307MB` from `414MB`

Signed-off-by: Uni Sayo <unibtc@gmail.com>