### PR TITLE
[theia-full] Use ENTRYPOINT instead of CMD

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -154,4 +154,4 @@ RUN yarn theia build
 EXPOSE 3000
 ENV SHELL /bin/bash
 
-CMD [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]
+ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]


### PR DESCRIPTION
Using ENTRYPOINT would allow node option such as `--inspect` to be passed along for debugging.

Signed-off-by: Uni Sayo <unibtc@gmail.com>