### PR TITLE
[theia-docker] .yarnclean file

### DIFF
--- a/theia-docker/.yarnclean
+++ b/theia-docker/.yarnclean
@@ -1,0 +1,77 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+assets
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+tsconfig.json
+
+# md ts ts.map spec and theia src folders
+*.md
+*.ts
+*.tsx
+*.ts.map
+*.js.map
+*.spec.*
+@theia/**/src
+
+
+# files that are already on bundle.js
+electron*
+@theia/**/lib/browser
+@phosphor
+react*
+onigasm
+oniguruma
+@theia/monaco
+monaco-html
+monaco-css
+font-awesome
+@typefox/monaco-editor-core
+@theia/terminal/node_modules/xterm/dist/xterm.js
+
+# licenses
+LICENSE
+LICENSE.txt
+ThirdPartyNotices.txt
+
+# yarn/npm files
+.yarn-integrity
+yarn.lock
+package-lock.json

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -1,19 +1,18 @@
 FROM node:8-alpine
 RUN apk add --no-cache make gcc g++ python
 ARG version=latest
+ENV HOME /home/theia
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
 RUN yarn --pure-lockfile && \
     yarn theia build && \
     yarn --production && \
-    yarn autoclean --init && \
-    echo *.ts >> .yarnclean && \
-    echo *.ts.map >> .yarnclean && \
-    echo *.spec.* >> .yarnclean && \
-    yarn autoclean --force && \
-    rm -rf ./node_modules/electron && \
     yarn cache clean
+
+ADD .yarnclean ./.yarnclean
+RUN yarn autoclean --force && \
+    rm -rf yarn.lock .yarnclean .electron .node-gyp .npm .cache .config
 
 FROM node:8-alpine
 # See : https://github.com/theia-ide/theia-apps/issues/34


### PR DESCRIPTION
This is in relation with https://github.com/theia-ide/theia-apps/pull/94 and in reference to https://github.com/eclipse/che/pull/11765

Separating the .yarnclean file makes it easier to add new files/folders to it. 

Also removing unused modules since they are already bundled to bundle.js and bundle.js.map files.

Image size is around 210MB

Signed-off-by: Uni Sayo <unibtc@gmail.com>