### PR TITLE
Ci add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ branches:
 language: generic
 
 env:
+  - NPM_TAG=latest IMAGE_NAME=theia-full
+  - NPM_TAG=next IMAGE_NAME=theia-full
   - NPM_TAG=latest IMAGE_NAME=theia
   - NPM_TAG=next IMAGE_NAME=theia
   - NPM_TAG=latest IMAGE_NAME=theia-java
@@ -27,8 +29,6 @@ env:
   - NPM_TAG=next IMAGE_NAME=yangster
   - NPM_TAG=latest IMAGE_NAME=theia-python
   - NPM_TAG=next IMAGE_NAME=theia-python
-  - NPM_TAG=latest IMAGE_NAME=theia-full
-  - NPM_TAG=next IMAGE_NAME=theia-full
 
 install:
   - cd "$IMAGE_NAME-docker"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-sudo: required
+# sudo: required
 
 services:
   - docker
   
 before_install:
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  # - sudo apt-get update
+  # - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 git:
   depth: 1
@@ -37,6 +37,9 @@ install:
   - echo $IMAGE_TAG
   - travis_wait docker build --build-arg "version=$NPM_TAG" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
   - docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
+  - docker run -d -p 0.0.0.0:4000:3000 "$IMAGE_TAG"
+
+script: cd ../tests; yarn; yarn test-app-$IMAGE_NAME
 
 before_deploy:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
-# sudo: required
-
 services:
   - docker
-  
-before_install:
-  # - sudo apt-get update
-  # - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 git:
   depth: 1
@@ -35,7 +29,10 @@ install:
   - IMAGE="theiaide/$IMAGE_NAME"
   - IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
   - echo $IMAGE_TAG
-  - travis_wait docker build --build-arg "version=$NPM_TAG" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
+  # this makes it possible to see output of the docker build as it unfolds:
+  # from https://stackoverflow.com/questions/43918874/how-to-increase-no-activity-wait-time-in-travis-ci
+  - "travis_wait 30 sleep 1800 &"
+  - docker build --build-arg "version=$NPM_TAG" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
   - docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
   - docker run -d -p 0.0.0.0:4000:3000 "$IMAGE_TAG"
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+lib
+yarn.lock
+

--- a/tests/LICENSE.3rd-party
+++ b/tests/LICENSE.3rd-party
@@ -1,0 +1,645 @@
+This folder contains files from the main Theia project (https://github.com/theia-ide/theia), under the following licenses:
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0, or GNU General Public License, version 2
+with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.
+
+# Eclipse Public License - v 2.0
+
+        THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+        PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+        OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+    1. DEFINITIONS
+
+    "Contribution" means:
+
+      a) in the case of the initial Contributor, the initial content
+         Distributed under this Agreement, and
+
+      b) in the case of each subsequent Contributor:
+         i) changes to the Program, and
+         ii) additions to the Program;
+      where such changes and/or additions to the Program originate from
+      and are Distributed by that particular Contributor. A Contribution
+      "originates" from a Contributor if it was added to the Program by
+      such Contributor itself or anyone acting on such Contributor's behalf.
+      Contributions do not include changes or additions to the Program that
+      are not Modified Works.
+
+    "Contributor" means any person or entity that Distributes the Program.
+
+    "Licensed Patents" mean patent claims licensable by a Contributor which
+    are necessarily infringed by the use or sale of its Contribution alone
+    or when combined with the Program.
+
+    "Program" means the Contributions Distributed in accordance with this
+    Agreement.
+
+    "Recipient" means anyone who receives the Program under this Agreement
+    or any Secondary License (as applicable), including Contributors.
+
+    "Derivative Works" shall mean any work, whether in Source Code or other
+    form, that is based on (or derived from) the Program and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship.
+
+    "Modified Works" shall mean any work in Source Code or other form that
+    results from an addition to, deletion from, or modification of the
+    contents of the Program, including, for purposes of clarity any new file
+    in Source Code form that contains any contents of the Program. Modified
+    Works shall not include works that contain only declarations,
+    interfaces, types, classes, structures, or files of the Program solely
+    in each case in order to link to, bind by name, or subclass the Program
+    or Modified Works thereof.
+
+    "Distribute" means the acts of a) distributing or b) making available
+    in any manner that enables the transfer of a copy.
+
+    "Source Code" means the form of a Program preferred for making
+    modifications, including but not limited to software source code,
+    documentation source, and configuration files.
+
+    "Secondary License" means either the GNU General Public License,
+    Version 2.0, or any later versions of that license, including any
+    exceptions or additional permissions as identified by the initial
+    Contributor.
+
+    2. GRANT OF RIGHTS
+
+      a) Subject to the terms of this Agreement, each Contributor hereby
+      grants Recipient a non-exclusive, worldwide, royalty-free copyright
+      license to reproduce, prepare Derivative Works of, publicly display,
+      publicly perform, Distribute and sublicense the Contribution of such
+      Contributor, if any, and such Derivative Works.
+
+      b) Subject to the terms of this Agreement, each Contributor hereby
+      grants Recipient a non-exclusive, worldwide, royalty-free patent
+      license under Licensed Patents to make, use, sell, offer to sell,
+      import and otherwise transfer the Contribution of such Contributor,
+      if any, in Source Code or other form. This patent license shall
+      apply to the combination of the Contribution and the Program if, at
+      the time the Contribution is added by the Contributor, such addition
+      of the Contribution causes such combination to be covered by the
+      Licensed Patents. The patent license shall not apply to any other
+      combinations which include the Contribution. No hardware per se is
+      licensed hereunder.
+
+      c) Recipient understands that although each Contributor grants the
+      licenses to its Contributions set forth herein, no assurances are
+      provided by any Contributor that the Program does not infringe the
+      patent or other intellectual property rights of any other entity.
+      Each Contributor disclaims any liability to Recipient for claims
+      brought by any other entity based on infringement of intellectual
+      property rights or otherwise. As a condition to exercising the
+      rights and licenses granted hereunder, each Recipient hereby
+      assumes sole responsibility to secure any other intellectual
+      property rights needed, if any. For example, if a third party
+      patent license is required to allow Recipient to Distribute the
+      Program, it is Recipient's responsibility to acquire that license
+      before distributing the Program.
+
+      d) Each Contributor represents that to its knowledge it has
+      sufficient copyright rights in its Contribution, if any, to grant
+      the copyright license set forth in this Agreement.
+
+      e) Notwithstanding the terms of any Secondary License, no
+      Contributor makes additional grants to any Recipient (other than
+      those set forth in this Agreement) as a result of such Recipient's
+      receipt of the Program under the terms of a Secondary License
+      (if permitted under the terms of Section 3).
+
+    3. REQUIREMENTS
+
+    3.1 If a Contributor Distributes the Program in any form, then:
+
+      a) the Program must also be made available as Source Code, in
+      accordance with section 3.2, and the Contributor must accompany
+      the Program with a statement that the Source Code for the Program
+      is available under this Agreement, and informs Recipients how to
+      obtain it in a reasonable manner on or through a medium customarily
+      used for software exchange; and
+
+      b) the Contributor may Distribute the Program under a license
+      different than this Agreement, provided that such license:
+         i) effectively disclaims on behalf of all other Contributors all
+         warranties and conditions, express and implied, including
+         warranties or conditions of title and non-infringement, and
+         implied warranties or conditions of merchantability and fitness
+         for a particular purpose;
+
+         ii) effectively excludes on behalf of all other Contributors all
+         liability for damages, including direct, indirect, special,
+         incidental and consequential damages, such as lost profits;
+
+         iii) does not attempt to limit or alter the recipients' rights
+         in the Source Code under section 3.2; and
+
+         iv) requires any subsequent distribution of the Program by any
+         party to be under a license that satisfies the requirements
+         of this section 3.
+
+    3.2 When the Program is Distributed as Source Code:
+
+      a) it must be made available under this Agreement, or if the
+      Program (i) is combined with other material in a separate file or
+      files made available under a Secondary License, and (ii) the initial
+      Contributor attached to the Source Code the notice described in
+      Exhibit A of this Agreement, then the Program may be made available
+      under the terms of such Secondary Licenses, and
+
+      b) a copy of this Agreement must be included with each copy of
+      the Program.
+
+    3.3 Contributors may not remove or alter any copyright, patent,
+    trademark, attribution notices, disclaimers of warranty, or limitations
+    of liability ("notices") contained within the Program from any copy of
+    the Program which they Distribute, provided that Contributors may add
+    their own appropriate notices.
+
+    4. COMMERCIAL DISTRIBUTION
+
+    Commercial distributors of software may accept certain responsibilities
+    with respect to end users, business partners and the like. While this
+    license is intended to facilitate the commercial use of the Program,
+    the Contributor who includes the Program in a commercial product
+    offering should do so in a manner which does not create potential
+    liability for other Contributors. Therefore, if a Contributor includes
+    the Program in a commercial product offering, such Contributor
+    ("Commercial Contributor") hereby agrees to defend and indemnify every
+    other Contributor ("Indemnified Contributor") against any losses,
+    damages and costs (collectively "Losses") arising from claims, lawsuits
+    and other legal actions brought by a third party against the Indemnified
+    Contributor to the extent caused by the acts or omissions of such
+    Commercial Contributor in connection with its distribution of the Program
+    in a commercial product offering. The obligations in this section do not
+    apply to any claims or Losses relating to any actual or alleged
+    intellectual property infringement. In order to qualify, an Indemnified
+    Contributor must: a) promptly notify the Commercial Contributor in
+    writing of such claim, and b) allow the Commercial Contributor to control,
+    and cooperate with the Commercial Contributor in, the defense and any
+    related settlement negotiations. The Indemnified Contributor may
+    participate in any such claim at its own expense.
+
+    For example, a Contributor might include the Program in a commercial
+    product offering, Product X. That Contributor is then a Commercial
+    Contributor. If that Commercial Contributor then makes performance
+    claims, or offers warranties related to Product X, those performance
+    claims and warranties are such Commercial Contributor's responsibility
+    alone. Under this section, the Commercial Contributor would have to
+    defend claims against the other Contributors related to those performance
+    claims and warranties, and if a court requires any other Contributor to
+    pay any damages as a result, the Commercial Contributor must pay
+    those damages.
+
+    5. NO WARRANTY
+
+    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+    PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+    IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+    TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+    PURPOSE. Each Recipient is solely responsible for determining the
+    appropriateness of using and distributing the Program and assumes all
+    risks associated with its exercise of rights under this Agreement,
+    including but not limited to the risks and costs of program errors,
+    compliance with applicable laws, damage to or loss of data, programs
+    or equipment, and unavailability or interruption of operations.
+
+    6. DISCLAIMER OF LIABILITY
+
+    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+    PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+    SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+    PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+    EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGES.
+
+    7. GENERAL
+
+    If any provision of this Agreement is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of
+    the remainder of the terms of this Agreement, and without further
+    action by the parties hereto, such provision shall be reformed to the
+    minimum extent necessary to make such provision valid and enforceable.
+
+    If Recipient institutes patent litigation against any entity
+    (including a cross-claim or counterclaim in a lawsuit) alleging that the
+    Program itself (excluding combinations of the Program with other software
+    or hardware) infringes such Recipient's patent(s), then such Recipient's
+    rights granted under Section 2(b) shall terminate as of the date such
+    litigation is filed.
+
+    All Recipient's rights under this Agreement shall terminate if it
+    fails to comply with any of the material terms or conditions of this
+    Agreement and does not cure such failure in a reasonable period of
+    time after becoming aware of such noncompliance. If all Recipient's
+    rights under this Agreement terminate, Recipient agrees to cease use
+    and distribution of the Program as soon as reasonably practicable.
+    However, Recipient's obligations under this Agreement and any licenses
+    granted by Recipient relating to the Program shall continue and survive.
+
+    Everyone is permitted to copy and distribute copies of this Agreement,
+    but in order to avoid inconsistency the Agreement is copyrighted and
+    may only be modified in the following manner. The Agreement Steward
+    reserves the right to publish new versions (including revisions) of
+    this Agreement from time to time. No one other than the Agreement
+    Steward has the right to modify this Agreement. The Eclipse Foundation
+    is the initial Agreement Steward. The Eclipse Foundation may assign the
+    responsibility to serve as the Agreement Steward to a suitable separate
+    entity. Each new version of the Agreement will be given a distinguishing
+    version number. The Program (including Contributions) may always be
+    Distributed subject to the version of the Agreement under which it was
+    received. In addition, after a new version of the Agreement is published,
+    Contributor may elect to Distribute the Program (including its
+    Contributions) under the new version.
+
+    Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+    receives no rights or licenses to the intellectual property of any
+    Contributor under this Agreement, whether expressly, by implication,
+    estoppel or otherwise. All rights in the Program not expressly granted
+    under this Agreement are reserved. Nothing in this Agreement is intended
+    to be enforceable by any entity that is not a Contributor or Recipient.
+    No third-party beneficiary rights are created under this Agreement.
+
+    Exhibit A - Form of Secondary Licenses Notice
+
+    "This Source Code may also be made available under the following 
+    Secondary Licenses when the conditions for such availability set forth 
+    in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+    version(s), and exceptions or additional permissions here}."
+
+      Simply including a copy of this Agreement, including this Exhibit A
+      is not sufficient to license the Source Code under Secondary Licenses.
+
+      If it is not possible or desirable to put the notice in a particular
+      file, then You may include the notice in a location (such as a LICENSE
+      file in a relevant directory) where a recipient would be likely to
+      look for such a notice.
+
+      You may add additional accurate notices of copyright ownership.
+
+---
+
+##    The GNU General Public License (GPL) Version 2, June 1991
+
+    Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+    51 Franklin Street, Fifth Floor
+    Boston, MA 02110-1335
+    USA
+
+    Everyone is permitted to copy and distribute verbatim copies
+    of this license document, but changing it is not allowed.
+
+    Preamble
+
+    The licenses for most software are designed to take away your freedom to
+    share and change it. By contrast, the GNU General Public License is
+    intended to guarantee your freedom to share and change free software--to
+    make sure the software is free for all its users. This General Public
+    License applies to most of the Free Software Foundation's software and
+    to any other program whose authors commit to using it. (Some other Free
+    Software Foundation software is covered by the GNU Library General
+    Public License instead.) You can apply it to your programs, too.
+
+    When we speak of free software, we are referring to freedom, not price.
+    Our General Public Licenses are designed to make sure that you have the
+    freedom to distribute copies of free software (and charge for this
+    service if you wish), that you receive source code or can get it if you
+    want it, that you can change the software or use pieces of it in new
+    free programs; and that you know you can do these things.
+
+    To protect your rights, we need to make restrictions that forbid anyone
+    to deny you these rights or to ask you to surrender the rights. These
+    restrictions translate to certain responsibilities for you if you
+    distribute copies of the software, or if you modify it.
+
+    For example, if you distribute copies of such a program, whether gratis
+    or for a fee, you must give the recipients all the rights that you have.
+    You must make sure that they, too, receive or can get the source code.
+    And you must show them these terms so they know their rights.
+
+    We protect your rights with two steps: (1) copyright the software, and
+    (2) offer you this license which gives you legal permission to copy,
+    distribute and/or modify the software.
+
+    Also, for each author's protection and ours, we want to make certain
+    that everyone understands that there is no warranty for this free
+    software. If the software is modified by someone else and passed on, we
+    want its recipients to know that what they have is not the original, so
+    that any problems introduced by others will not reflect on the original
+    authors' reputations.
+
+    Finally, any free program is threatened constantly by software patents.
+    We wish to avoid the danger that redistributors of a free program will
+    individually obtain patent licenses, in effect making the program
+    proprietary. To prevent this, we have made it clear that any patent must
+    be licensed for everyone's free use or not licensed at all.
+
+    The precise terms and conditions for copying, distribution and
+    modification follow.
+
+    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+    0. This License applies to any program or other work which contains a
+    notice placed by the copyright holder saying it may be distributed under
+    the terms of this General Public License. The "Program", below, refers
+    to any such program or work, and a "work based on the Program" means
+    either the Program or any derivative work under copyright law: that is
+    to say, a work containing the Program or a portion of it, either
+    verbatim or with modifications and/or translated into another language.
+    (Hereinafter, translation is included without limitation in the term
+    "modification".) Each licensee is addressed as "you".
+
+    Activities other than copying, distribution and modification are not
+    covered by this License; they are outside its scope. The act of running
+    the Program is not restricted, and the output from the Program is
+    covered only if its contents constitute a work based on the Program
+    (independent of having been made by running the Program). Whether that
+    is true depends on what the Program does.
+
+    1. You may copy and distribute verbatim copies of the Program's source
+    code as you receive it, in any medium, provided that you conspicuously
+    and appropriately publish on each copy an appropriate copyright notice
+    and disclaimer of warranty; keep intact all the notices that refer to
+    this License and to the absence of any warranty; and give any other
+    recipients of the Program a copy of this License along with the Program.
+
+    You may charge a fee for the physical act of transferring a copy, and
+    you may at your option offer warranty protection in exchange for a fee.
+
+    2. You may modify your copy or copies of the Program or any portion of
+    it, thus forming a work based on the Program, and copy and distribute
+    such modifications or work under the terms of Section 1 above, provided
+    that you also meet all of these conditions:
+
+        a) You must cause the modified files to carry prominent notices
+        stating that you changed the files and the date of any change.
+
+        b) You must cause any work that you distribute or publish, that in
+        whole or in part contains or is derived from the Program or any part
+        thereof, to be licensed as a whole at no charge to all third parties
+        under the terms of this License.
+
+        c) If the modified program normally reads commands interactively
+        when run, you must cause it, when started running for such
+        interactive use in the most ordinary way, to print or display an
+        announcement including an appropriate copyright notice and a notice
+        that there is no warranty (or else, saying that you provide a
+        warranty) and that users may redistribute the program under these
+        conditions, and telling the user how to view a copy of this License.
+        (Exception: if the Program itself is interactive but does not
+        normally print such an announcement, your work based on the Program
+        is not required to print an announcement.)
+
+    These requirements apply to the modified work as a whole. If
+    identifiable sections of that work are not derived from the Program, and
+    can be reasonably considered independent and separate works in
+    themselves, then this License, and its terms, do not apply to those
+    sections when you distribute them as separate works. But when you
+    distribute the same sections as part of a whole which is a work based on
+    the Program, the distribution of the whole must be on the terms of this
+    License, whose permissions for other licensees extend to the entire
+    whole, and thus to each and every part regardless of who wrote it.
+
+    Thus, it is not the intent of this section to claim rights or contest
+    your rights to work written entirely by you; rather, the intent is to
+    exercise the right to control the distribution of derivative or
+    collective works based on the Program.
+
+    In addition, mere aggregation of another work not based on the Program
+    with the Program (or with a work based on the Program) on a volume of a
+    storage or distribution medium does not bring the other work under the
+    scope of this License.
+
+    3. You may copy and distribute the Program (or a work based on it,
+    under Section 2) in object code or executable form under the terms of
+    Sections 1 and 2 above provided that you also do one of the following:
+
+        a) Accompany it with the complete corresponding machine-readable
+        source code, which must be distributed under the terms of Sections 1
+        and 2 above on a medium customarily used for software interchange; or,
+
+        b) Accompany it with a written offer, valid for at least three
+        years, to give any third party, for a charge no more than your cost
+        of physically performing source distribution, a complete
+        machine-readable copy of the corresponding source code, to be
+        distributed under the terms of Sections 1 and 2 above on a medium
+        customarily used for software interchange; or,
+
+        c) Accompany it with the information you received as to the offer to
+        distribute corresponding source code. (This alternative is allowed
+        only for noncommercial distribution and only if you received the
+        program in object code or executable form with such an offer, in
+        accord with Subsection b above.)
+
+    The source code for a work means the preferred form of the work for
+    making modifications to it. For an executable work, complete source code
+    means all the source code for all modules it contains, plus any
+    associated interface definition files, plus the scripts used to control
+    compilation and installation of the executable. However, as a special
+    exception, the source code distributed need not include anything that is
+    normally distributed (in either source or binary form) with the major
+    components (compiler, kernel, and so on) of the operating system on
+    which the executable runs, unless that component itself accompanies the
+    executable.
+
+    If distribution of executable or object code is made by offering access
+    to copy from a designated place, then offering equivalent access to copy
+    the source code from the same place counts as distribution of the source
+    code, even though third parties are not compelled to copy the source
+    along with the object code.
+
+    4. You may not copy, modify, sublicense, or distribute the Program
+    except as expressly provided under this License. Any attempt otherwise
+    to copy, modify, sublicense or distribute the Program is void, and will
+    automatically terminate your rights under this License. However, parties
+    who have received copies, or rights, from you under this License will
+    not have their licenses terminated so long as such parties remain in
+    full compliance.
+
+    5. You are not required to accept this License, since you have not
+    signed it. However, nothing else grants you permission to modify or
+    distribute the Program or its derivative works. These actions are
+    prohibited by law if you do not accept this License. Therefore, by
+    modifying or distributing the Program (or any work based on the
+    Program), you indicate your acceptance of this License to do so, and all
+    its terms and conditions for copying, distributing or modifying the
+    Program or works based on it.
+
+    6. Each time you redistribute the Program (or any work based on the
+    Program), the recipient automatically receives a license from the
+    original licensor to copy, distribute or modify the Program subject to
+    these terms and conditions. You may not impose any further restrictions
+    on the recipients' exercise of the rights granted herein. You are not
+    responsible for enforcing compliance by third parties to this License.
+
+    7. If, as a consequence of a court judgment or allegation of patent
+    infringement or for any other reason (not limited to patent issues),
+    conditions are imposed on you (whether by court order, agreement or
+    otherwise) that contradict the conditions of this License, they do not
+    excuse you from the conditions of this License. If you cannot distribute
+    so as to satisfy simultaneously your obligations under this License and
+    any other pertinent obligations, then as a consequence you may not
+    distribute the Program at all. For example, if a patent license would
+    not permit royalty-free redistribution of the Program by all those who
+    receive copies directly or indirectly through you, then the only way you
+    could satisfy both it and this License would be to refrain entirely from
+    distribution of the Program.
+
+    If any portion of this section is held invalid or unenforceable under
+    any particular circumstance, the balance of the section is intended to
+    apply and the section as a whole is intended to apply in other
+    circumstances.
+
+    It is not the purpose of this section to induce you to infringe any
+    patents or other property right claims or to contest validity of any
+    such claims; this section has the sole purpose of protecting the
+    integrity of the free software distribution system, which is implemented
+    by public license practices. Many people have made generous
+    contributions to the wide range of software distributed through that
+    system in reliance on consistent application of that system; it is up to
+    the author/donor to decide if he or she is willing to distribute
+    software through any other system and a licensee cannot impose that choice.
+
+    This section is intended to make thoroughly clear what is believed to be
+    a consequence of the rest of this License.
+
+    8. If the distribution and/or use of the Program is restricted in
+    certain countries either by patents or by copyrighted interfaces, the
+    original copyright holder who places the Program under this License may
+    add an explicit geographical distribution limitation excluding those
+    countries, so that distribution is permitted only in or among countries
+    not thus excluded. In such case, this License incorporates the
+    limitation as if written in the body of this License.
+
+    9. The Free Software Foundation may publish revised and/or new
+    versions of the General Public License from time to time. Such new
+    versions will be similar in spirit to the present version, but may
+    differ in detail to address new problems or concerns.
+
+    Each version is given a distinguishing version number. If the Program
+    specifies a version number of this License which applies to it and "any
+    later version", you have the option of following the terms and
+    conditions either of that version or of any later version published by
+    the Free Software Foundation. If the Program does not specify a version
+    number of this License, you may choose any version ever published by the
+    Free Software Foundation.
+
+    10. If you wish to incorporate parts of the Program into other free
+    programs whose distribution conditions are different, write to the
+    author to ask for permission. For software which is copyrighted by the
+    Free Software Foundation, write to the Free Software Foundation; we
+    sometimes make exceptions for this. Our decision will be guided by the
+    two goals of preserving the free status of all derivatives of our free
+    software and of promoting the sharing and reuse of software generally.
+
+    NO WARRANTY
+
+    11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+    WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+    EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+    OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+    EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+    ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH
+    YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
+    NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+    12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+    WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+    AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+    DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+    DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+    (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+    INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+    THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR
+    OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+    END OF TERMS AND CONDITIONS
+
+    How to Apply These Terms to Your New Programs
+
+    If you develop a new program, and you want it to be of the greatest
+    possible use to the public, the best way to achieve this is to make it
+    free software which everyone can redistribute and change under these terms.
+
+    To do so, attach the following notices to the program. It is safest to
+    attach them to the start of each source file to most effectively convey
+    the exclusion of warranty; and each file should have at least the
+    "copyright" line and a pointer to where the full notice is found.
+
+        One line to give the program's name and a brief idea of what it does.
+        Copyright (C) <year> <name of author>
+
+        This program is free software; you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation; either version 2 of the License, or
+        (at your option) any later version.
+
+        This program is distributed in the hope that it will be useful, but
+        WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+        General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software
+        Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
+
+    Also add information on how to contact you by electronic and paper mail.
+
+    If the program is interactive, make it output a short notice like this
+    when it starts in an interactive mode:
+
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
+        `show w'. This is free software, and you are welcome to redistribute
+        it under certain conditions; type `show c' for details.
+
+    The hypothetical commands `show w' and `show c' should show the
+    appropriate parts of the General Public License. Of course, the commands
+    you use may be called something other than `show w' and `show c'; they
+    could even be mouse-clicks or menu items--whatever suits your program.
+
+    You should also get your employer (if you work as a programmer) or your
+    school, if any, to sign a "copyright disclaimer" for the program, if
+    necessary. Here is a sample; alter the names:
+
+        Yoyodyne, Inc., hereby disclaims all copyright interest in the
+        program `Gnomovision' (which makes passes at compilers) written by
+        James Hacker.
+
+        signature of Ty Coon, 1 April 1989
+        Ty Coon, President of Vice
+
+    This General Public License does not permit incorporating your program
+    into proprietary programs. If your program is a subroutine library, you
+    may consider it more useful to permit linking proprietary applications
+    with the library. If this is what you want to do, use the GNU Library
+    General Public License instead of this License.
+
+---
+
+## CLASSPATH EXCEPTION
+
+    Linking this library statically or dynamically with other modules is
+    making a combined work based on this library.  Thus, the terms and
+    conditions of the GNU General Public License version 2 cover the whole
+    combination.
+
+    As a special exception, the copyright holders of this library give you
+    permission to link this library with independent modules to produce an
+    executable, regardless of the license terms of these independent
+    modules, and to copy and distribute the resulting executable under
+    terms of your choice, provided that you also meet, for each linked
+    independent module, the terms and conditions of the license of that
+    module.  An independent module is a module which is not derived from or
+    based on this library.  If you modify this library, you may extend this
+    exception to your version of the library, but you are not obligated to
+    do so.  If you do not wish to do so, delete this exception statement
+    from your version.
+

--- a/tests/bottom-panel/bottom-panel.ts
+++ b/tests/bottom-panel/bottom-panel.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'webdriverio';
+
+export class BottomPanel {
+
+    constructor(protected readonly driver: WebdriverIO.Client<void>) { }
+
+    doesTabExist(tabName: string): boolean {
+        return this.driver.element('#theia-bottom-content-panel .p-TabBar .p-TabBar-content').isExisting(`div=${tabName}`);
+    }
+
+    isTabActive(tabName: string): boolean {
+        const tab = this.driver.element('#theia-bottom-content-panel .p-TabBar .p-TabBar-content').element(`div=${tabName}`);
+        /* Check if the parent li container has the p-mod-current class which makes it active*/
+        return (tab.$('..').getAttribute('class').split(' ').indexOf('p-mod-current') > -1);
+    }
+
+    openTab(tabName: string) {
+        this.driver.element('#theia-bottom-content-panel .p-TabBar .p-TabBar-content').click(`div=${tabName}`);
+    }
+
+    isTerminalVisible(): boolean {
+        return this.driver.isExisting('.p-Widget div.terminal.xterm');
+    }
+
+    waitForTerminal() {
+        this.driver.waitForExist('.p-Widget div.terminal.xterm');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isProblemsViewVisible(): boolean {
+        return this.driver.isExisting('.p-Widget div.theia-marker-container');
+    }
+
+    waitForProblemsView() {
+        this.driver.waitForExist('.p-Widget div.theia-marker-container');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isCallHierarchyViewVisible(): boolean {
+        return this.driver.isExisting('#callhierarchy');
+    }
+
+    waitForCallHierarchyView() {
+        this.driver.waitForExist('#callhierarchy');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isOutputViewVisible(): boolean {
+        return this.driver.isExisting('.p-Widget div.theia-output');
+    }
+
+    waitForOutputView() {
+        this.driver.waitForExist('.p-Widget div.theia-output');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    closeCurrentView() {
+        this.driver.click('#theia-bottom-content-panel .p-TabBar-tab.p-mod-current .p-TabBar-tabCloseIcon');
+    }
+
+}

--- a/tests/left-panel/left-panel.ts
+++ b/tests/left-panel/left-panel.ts
@@ -1,0 +1,136 @@
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'webdriverio';
+
+export class LeftPanel {
+
+    constructor(protected readonly driver: WebdriverIO.Client<void>) { }
+
+    doesTabExist(tabName: string): boolean {
+        return this.driver.element('.p-TabBar.theia-app-left .p-TabBar-content').isExisting(`div=${tabName}`);
+    }
+
+    isTabActive(tabName: string): boolean {
+        const tab = this.driver.element('.p-TabBar.theia-app-left .p-TabBar-content').element(`div=${tabName}`);
+        /* Check if the parent li container has the p-mod-current class which makes it active */
+        return (tab.$('..').getAttribute('class').split(' ').indexOf('p-mod-current') !== -1);
+    }
+
+    openCloseTab(tabName: string) {
+        this.driver.element('.p-TabBar.theia-app-left .p-TabBar-content').click(`div=${tabName}`);
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    collapseTab(tabName: string) {
+        this.driver.element('.p-TabBar.theia-app-left .p-TabBar-content').rightClick(`div=${tabName}`);
+        this.driver.element('.p-Widget.p-Menu .p-Menu-content').click('div=Collapse');
+    }
+
+    isFileTreeVisible(): boolean {
+        return (this.driver.isExisting('#files') && this.driver.element('#files').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1
+            && this.isPanelVisible());
+    }
+
+    waitForFilesViewVisible(): void {
+        this.driver.waitForVisible('#files');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    /**
+     * Click on the first node named `name` in the files view to expand or
+     * collapse it.  No check is done to make sure this node actually exists or
+     * represents a directory.
+     */
+    toggleDirectoryInFilesView(name: string) {
+        this.waitForFilesViewVisible();
+        const files = this.driver.element('#files');
+        const element = files.element('div=' + name);
+        element.click();
+        this.driver.pause(300);
+    }
+
+    /**
+     * Double click on the first node named `name` in the files view to open
+     * it.  Not check is done to make sure this node actually exists or
+     * represents a file.
+     */
+    openFileInFilesView(name: string) {
+        this.waitForFilesViewVisible();
+        const files = this.driver.element('#files');
+        const element = files.element('div=' + name);
+        element.doubleClick();
+        this.driver.pause(300);
+    }
+
+    isGitContainerVisible(): boolean {
+        return (this.driver.isExisting('#theia-gitContainer') && this.driver.element('#theia-gitContainer').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1
+            && this.isPanelVisible());
+    }
+
+    waitForGitViewVisible(): void {
+        this.driver.waitForVisible('#theia-gitContainer');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isExtensionsContainerVisible(): boolean {
+        return this.driver.isExisting('#extensions') && (this.driver.element('#extensions').getAttribute('class').split(' ').indexOf('theia-extensions') !== -1);
+    }
+
+    waitForExtensionsViewVisible(): void {
+        this.driver.waitForVisible('#extensions');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isGitHistoryContainerVisible(): boolean {
+        return (this.driver.isExisting('#git-history') && this.driver.element('#git-history').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1
+            && this.isPanelVisible());
+    }
+
+    waitForGitHistoryViewVisible(): void {
+        this.driver.waitForVisible('#git-history');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isPluginsViewVisible(): boolean {
+        return this.driver.isExisting('.p-Widget div.theia-output') && this.driver.element('#plugins').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1;
+    }
+
+    waitForPluginsViewVisible(): void {
+        this.driver.waitForVisible('#plugins');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    isSearchViewVisible(): boolean {
+        return this.driver.isExisting('#search-in-workspace') && this.driver.element('#search-in-workspace').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1;
+    }
+
+    waitForSearchViewVisible(): void {
+        this.driver.waitForVisible('#search-in-workspace');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    protected isPanelVisible(): boolean {
+        return (this.driver.element('#theia-left-side-panel').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1);
+    }
+}

--- a/tests/left-panel/left-panel.ui-spec.ts
+++ b/tests/left-panel/left-panel.ui-spec.ts
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* tslint:disable:no-unused-expression*/
+import { expect } from 'chai';
+import { LeftPanel } from './left-panel';
+import { MainPage } from '../main-page/main-page';
+let leftPanel: LeftPanel;
+let mainPage: MainPage;
+
+before(() => {
+    const driver = browser;
+    const url = '/';
+
+    driver.url(url);
+    leftPanel = new LeftPanel(driver);
+    mainPage = new MainPage(driver);
+    // Make sure that the application shell is loaded
+    mainPage.waitForStartup();
+});
+
+describe('theia left panel', () => {
+    it("should show 'Files' and 'Git'", () => {
+        expect(leftPanel.doesTabExist('Files')).to.be.true;
+        expect(leftPanel.doesTabExist('Git')).to.be.true;
+    });
+
+    describe('files tab', () => {
+        it('should open/close the files tab', () => {
+            leftPanel.openCloseTab('Files');
+            expect(leftPanel.isFileTreeVisible()).to.be.true;
+            expect(leftPanel.isTabActive('Files')).to.be.true;
+
+            leftPanel.openCloseTab('Files');
+            expect(leftPanel.isFileTreeVisible()).to.be.false;
+            expect(leftPanel.isTabActive('Files')).to.be.false;
+        });
+    });
+
+    describe('git tab', () => {
+        it('should open/close the git tab', () => {
+            leftPanel.openCloseTab('Git');
+            expect(leftPanel.isGitContainerVisible()).to.be.true;
+            expect(leftPanel.isTabActive('Git')).to.be.true;
+
+            leftPanel.openCloseTab('Git');
+            expect(leftPanel.isGitContainerVisible()).to.be.false;
+            expect(leftPanel.isTabActive('Git')).to.be.false;
+        });
+    });
+});

--- a/tests/main-page/main-page.ts
+++ b/tests/main-page/main-page.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'webdriverio';
+import { TopPanel } from '../top-panel/top-panel';
+import { LeftPanel } from '../left-panel/left-panel';
+
+export class MainPage {
+
+    protected readonly topPanel: TopPanel;
+    protected readonly leftPanel: LeftPanel;
+
+    constructor(protected readonly driver: WebdriverIO.Client<void>) {
+        this.topPanel = new TopPanel(driver);
+        this.leftPanel = new LeftPanel(driver);
+    }
+
+    applicationShellExists(): boolean {
+        return this.driver.waitForExist('#theia-app-shell');
+    }
+
+    waitForStartup(): void {
+        this.driver.waitUntil(() => !this.driver.isExisting('.theia-preload'));
+    }
+
+    mainContentPanelExists(): boolean {
+        return this.driver.waitForExist('#theia-main-content-panel');
+    }
+
+    theiaTopPanelExists(): boolean {
+        return this.driver.waitForExist('#theia-top-panel');
+    }
+
+    rightSideBarExists(): boolean {
+        return this.driver.waitForExist('div.p-TabBar.theia-app-right');
+    }
+
+    leftSideBarExists(): boolean {
+        return this.driver.waitForExist('div.p-TabBar.theia-app-left');
+    }
+
+    statusBarExists(): boolean {
+        return this.driver.waitForExist('div#theia-statusBar');
+    }
+
+    closeAll() {
+        /* Make sure that all the "docked" layouts are closed */
+        while (this.driver.isExisting('.p-Widget.p-TabBar .p-TabBar-tab.p-mod-closable')) {
+            this.driver.rightClick('.p-Widget.p-TabBar .p-TabBar-tab.p-mod-closable');
+            this.driver.element('.p-Widget.p-Menu .p-Menu-content').click('div=Close All');
+        }
+    }
+}

--- a/tests/main-page/main-page.ui-spec.ts
+++ b/tests/main-page/main-page.ui-spec.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* tslint:disable:no-unused-expression*/
+import { MainPage } from './main-page';
+import { expect } from 'chai';
+
+let mainPage: MainPage;
+let driver: WebdriverIO.Client<void>;
+
+describe('theia main page', () => {
+
+    before(() => {
+        const url = '/';
+        driver = browser;
+        driver.url(url);
+        mainPage = new MainPage(driver);
+        // Make sure that the application shell is loaded
+        mainPage.waitForStartup();
+    });
+
+    it('should show the application shell', () => {
+        expect(mainPage.applicationShellExists()).to.be.true;
+    });
+
+    it('should show the main content panel', () => {
+        expect(mainPage.mainContentPanelExists()).to.be.true;
+    });
+
+    it('should show the left and right sidebars', () => {
+        expect(mainPage.rightSideBarExists() && mainPage.leftSideBarExists()).to.be.true;
+    });
+
+    it('should show the status bar', () => {
+        expect(mainPage.statusBarExists()).to.be.true;
+    });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,29 @@
+{
+  "private": true,
+  "name": "tests_for_theia-apps",
+  "version": "0.0.1",
+  "scripts": {
+    "test": "wdio wdio.conf.js --theia-port 4000",
+    "test-app-theia": "wdio wdio.theia-docker.conf.js --theia-port 4000",
+    "test-app-theia-full": "yarn test",
+    "test-app-theia-go": "yarn test",
+    "test-app-theia-java": "yarn test",
+    "test-app-theia-python": "yarn test",
+    "test-app-yangster": "yarn test"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.0.1",
+    "@types/mocha": "^2.2.41",
+    "@types/webdriverio": "^4.7.0",
+    "chai": "^4.1.0",
+    "chai-string": "^1.4.0",
+    "reflect-metadata": "^0.1.10",
+    "temp": "^0.8.3",
+    "ts-node": "<7.0.0",
+    "typescript": "3.1.6",
+    "wdio-spec-reporter": "0.1.0",
+    "wdio-mocha-framework": "0.5.9",
+    "wdio-selenium-standalone-service": "0.0.8",
+    "webdriverio": "4.9.2"
+  }
+}

--- a/tests/right-panel/right-panel.ts
+++ b/tests/right-panel/right-panel.ts
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'webdriverio';
+
+export class RightPanel {
+
+    constructor(protected readonly driver: WebdriverIO.Client<void>) { }
+
+    doesTabExist(tabName: string): boolean {
+        return this.driver.element('.p-TabBar.theia-app-right .p-TabBar-content').isExisting(`div=${tabName}`);
+    }
+
+    isTabActive(tabName: string): boolean {
+        const tab = this.driver.element('.p-TabBar.theia-app-right .p-TabBar-content').element(`div=${tabName}`);
+        /* Check if the parent li container has the p-mod-current class which makes it active */
+        return (tab.$('..').getAttribute('class').split(' ').indexOf('p-mod-current') !== -1);
+    }
+
+    openCloseTab(tabName: string) {
+        this.driver.element('.p-TabBar.theia-app-right .p-TabBar-content').click(`div=${tabName}`);
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    collapseTab(tabName: string) {
+        this.driver.element('.p-TabBar.theia-app-right .p-TabBar-content').rightClick(`div=${tabName}`);
+        this.driver.element('.p-Widget.p-Menu .p-Menu-content').click('div=Collapse');
+    }
+
+    isOutlineViewVisible(): boolean {
+        return (this.isPanelVisible() && this.driver.isExisting('#outline-view'));
+    }
+
+    waitForOutlineViewVisible(): void {
+        this.driver.waitForVisible('#outline-view');
+        // Wait for animations to finish
+        this.driver.pause(300);
+    }
+
+    protected isPanelVisible(): boolean {
+        return (this.driver.element('#theia-right-side-panel').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1);
+    }
+}

--- a/tests/right-panel/right-panel.ui-spec.ts
+++ b/tests/right-panel/right-panel.ui-spec.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* tslint:disable:no-unused-expression*/
+import { expect } from 'chai';
+import { RightPanel } from './right-panel';
+import { MainPage } from '../main-page/main-page';
+let rightPanel: RightPanel;
+let mainPage: MainPage;
+
+before(() => {
+    const driver = browser;
+    const url = '/';
+
+    driver.url(url);
+    rightPanel = new RightPanel(driver);
+    mainPage = new MainPage(driver);
+    // Make sure that the application shell is loaded
+    mainPage.waitForStartup();
+});
+
+describe('theia right panel', () => {
+    it("should show 'Outline'", () => {
+        expect(rightPanel.doesTabExist('Outline')).to.be.true;
+    });
+
+    describe('outline tab', () => {
+        it('should open/close the outline tab', () => {
+            rightPanel.openCloseTab('Outline');
+            expect(rightPanel.isOutlineViewVisible()).to.be.true;
+            expect(rightPanel.isTabActive('Outline')).to.be.true;
+
+            rightPanel.openCloseTab('Outline');
+            expect(rightPanel.isOutlineViewVisible()).to.be.false;
+            expect(rightPanel.isTabActive('Outline')).to.be.false;
+        });
+    });
+
+});

--- a/tests/theia-docker/theia-docker.spec.ts
+++ b/tests/theia-docker/theia-docker.spec.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+let driver: WebdriverIO.Client<void>;
+
+describe('tests for application theia-docker go here', () => {
+
+    it('bogus test 1', () => {
+        
+    });
+
+    it('bogus test 2', () => {
+       
+    });
+
+});

--- a/tests/top-panel/top-panel.ts
+++ b/tests/top-panel/top-panel.ts
@@ -1,0 +1,121 @@
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import 'webdriverio';
+
+export class TopPanel {
+
+    public constructor(protected readonly driver: WebdriverIO.Client<void>) { }
+
+    exists(): boolean {
+        return this.driver.isExisting('div#theia-top-panel');
+    }
+
+    openNewTerminal() {
+        this.clickMenuTab('Terminal');
+        this.clickSubMenu('New Terminal');
+    }
+
+    toggleCallHierarchyView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Call Hierarchy');
+    }
+
+    toggleExtensionsView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Extensions');
+    }
+
+    toggleFilesView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Files');
+    }
+
+    toggleGitView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Git');
+    }
+
+    toggleGitHistoryView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Git History');
+    }
+
+    toggleOutlineView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Outline');
+    }
+
+    toggleOutputView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Output');
+    }
+
+    openPluginsView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Plugins');
+    }
+
+    openProblemsView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Problems');
+    }
+
+    toggleSearchView() {
+        this.clickMenuTab('View');
+        this.clickSubMenu('Search');
+    }
+
+    waitForSubMenu(): void {
+        this.driver.waitForExist('div.p-Widget.p-Menu.p-MenuBar-menu');
+    }
+
+    isSubMenuVisible(): boolean {
+        return this.driver.isExisting('div.p-Widget.p-Menu.p-MenuBar-menu');
+    }
+
+    clickMenuTab(tab: number | string) {
+        if (typeof tab === 'string') {
+            this.driver.element('ul.p-MenuBar-content').click(`div=${tab}`);
+        } else {
+            this.driver.click(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tab})`);
+        }
+    }
+
+    clickSubMenu(subMenuItem: string) {
+        this.driver.element('div.p-Widget.p-Menu.p-MenuBar-menu .p-Menu-content').click(`div=${subMenuItem}`);
+    }
+
+    hoverMenuTab(tabNumber: number) {
+        this.driver.moveToObject(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tabNumber})`);
+    }
+
+    isTabActive(tabNumber: number): boolean {
+        return this.driver.isExisting(`ul.p-MenuBar-content > .p-mod-active.p-MenuBar-item:nth-child(${tabNumber}`);
+    }
+
+    isMenuActive(): boolean {
+        return this.driver.isExisting('#theia\\:menubar.p-mod-active');
+    }
+
+    getxBarTabPosition(tabNumber: number) {
+        return this.driver.getLocation(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tabNumber}`, 'x');
+    }
+
+    getxSubMenuPosition(): number {
+        return this.driver.getLocation('div.p-Widget.p-Menu.p-MenuBar-menu', 'x');
+    }
+}

--- a/tests/top-panel/top-panel.ui-spec.ts
+++ b/tests/top-panel/top-panel.ui-spec.ts
@@ -1,0 +1,262 @@
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* tslint:disable:no-unused-expression*/
+import { expect } from 'chai';
+import { TopPanel } from './top-panel';
+import { BottomPanel } from '../bottom-panel/bottom-panel';
+import { RightPanel } from '../right-panel/right-panel';
+import { LeftPanel } from '../left-panel/left-panel';
+import { MainPage } from '../main-page/main-page';
+let topPanel: TopPanel;
+let bottomPanel: BottomPanel;
+let rightPanel: RightPanel;
+let leftPanel: LeftPanel;
+let mainPage: MainPage;
+
+before(() => {
+    const driver = browser;
+    const url = '/';
+
+    driver.url(url);
+    driver.localStorage('DELETE');
+    driver.refresh();
+    topPanel = new TopPanel(driver);
+    bottomPanel = new BottomPanel(driver);
+    rightPanel = new RightPanel(driver);
+    leftPanel = new LeftPanel(driver);
+    mainPage = new MainPage(driver);
+    // Make sure that the application shell is loaded
+    mainPage.waitForStartup();
+});
+
+describe('theia top panel (menubar)', () => {
+    it('should show the top panel', () => {
+        expect(topPanel.exists()).to.be.true;
+    });
+
+    it('should set a menu item active when hovered', () => {
+        topPanel.hoverMenuTab(1);
+        expect(topPanel.isTabActive(1)).to.be.true;
+
+        topPanel.hoverMenuTab(2);
+        expect(topPanel.isTabActive(1)).to.be.false;
+        expect(topPanel.isTabActive(2)).to.be.true;
+    });
+
+    it('should show menu correctly when clicked on a tab', () => {
+        /* No menu at the start */
+        expect(topPanel.isSubMenuVisible()).to.be.false;
+
+        /* Click on the first child */
+        topPanel.clickMenuTab(1);
+        expect(topPanel.isSubMenuVisible()).to.be.true;
+
+        /* Click again to make the menu disappear */
+        topPanel.clickMenuTab(1);
+        expect(topPanel.isSubMenuVisible()).to.be.false;
+
+        /* Make sure the menu location is directly under the bar tab */
+        topPanel.clickMenuTab(1);
+        let tabX = topPanel.getxBarTabPosition(1);
+        let menuX = topPanel.getxSubMenuPosition();
+        expect(tabX).to.be.equal(menuX);
+
+        /* Test with the second tab by hovering to the second one */
+        topPanel.hoverMenuTab(2);
+        tabX = topPanel.getxBarTabPosition(2);
+        menuX = topPanel.getxSubMenuPosition();
+        expect(tabX).to.be.equal(menuX);
+
+        topPanel.clickMenuTab(2);
+        expect(topPanel.isSubMenuVisible()).to.be.false;
+
+    });
+
+    describe('terminal UI', () => {
+        it('should open a new terminal and then close it', () => {
+            if (!bottomPanel.isTerminalVisible()) {
+                topPanel.openNewTerminal();
+                bottomPanel.waitForTerminal();
+            }
+            expect(bottomPanel.isTerminalVisible()).to.be.true;
+
+            bottomPanel.closeCurrentView();
+            expect(bottomPanel.isTerminalVisible()).to.be.false;
+        });
+    });
+
+    describe('call hierarchy view UI', () => {
+        it('should start with call hierarchy view not visible', () => {
+            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.false;
+        });
+        it('call hierarchy view should toggle-on then toggle-off', () => {
+            if (!bottomPanel.isCallHierarchyViewVisible()) {
+                topPanel.toggleCallHierarchyView();
+                bottomPanel.waitForCallHierarchyView();
+            }
+            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.true;
+            topPanel.toggleCallHierarchyView();
+            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.false;
+        });
+    });
+
+    describe('extensions view UI', () => {
+        it('should start with extensions view not visible', () => {
+            expect(leftPanel.isExtensionsContainerVisible()).to.be.false;
+        });
+        it('extensions view should toggle-on then toggle-off', () => {
+            if (!leftPanel.isExtensionsContainerVisible()) {
+                topPanel.toggleExtensionsView();
+                leftPanel.waitForExtensionsViewVisible();
+            }
+            expect(leftPanel.isExtensionsContainerVisible()).to.be.true;
+            topPanel.toggleExtensionsView();
+            expect(leftPanel.isExtensionsContainerVisible()).to.be.false;
+        });
+    });
+
+    describe('files view UI', () => {
+        it('should start with files view not visible', () => {
+            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        });
+        it('files view should toggle-on then toggle-off', () => {
+            if (!leftPanel.isFileTreeVisible()) {
+                topPanel.toggleFilesView();
+                leftPanel.waitForFilesViewVisible();
+            }
+            expect(leftPanel.isFileTreeVisible()).to.be.true;
+            topPanel.toggleFilesView();
+            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        });
+    });
+
+    describe('git view UI', () => {
+        // re-enable if/when we reset workbench layout between tests
+        // it('should start with git view not visible', () => {
+        //     expect(leftPanel.isGitContainerVisible()).to.be.false;
+        // });
+        it('git view should toggle-on then toggle-off', () => {
+            if (!leftPanel.isGitContainerVisible()) {
+                topPanel.toggleGitView();
+                leftPanel.waitForGitViewVisible();
+            }
+            expect(leftPanel.isGitContainerVisible()).to.be.true;
+            topPanel.toggleGitView();
+            expect(leftPanel.isGitContainerVisible()).to.be.false;
+        });
+    });
+
+    describe('git history view UI', () => {
+        it('should start with git history view not visible', () => {
+            expect(leftPanel.isGitHistoryContainerVisible()).to.be.false;
+        });
+
+        // note: skipping since git history view does not toggle ATM
+        // see: https://github.com/theia-ide/theia/issues/1727
+        it.skip('git history view should toggle-on then toggle-off', () => {
+            if (!leftPanel.isGitHistoryContainerVisible()) {
+                topPanel.toggleGitHistoryView();
+                leftPanel.waitForGitHistoryViewVisible();
+            }
+            expect(leftPanel.isGitHistoryContainerVisible()).to.be.true;
+            topPanel.toggleGitHistoryView();
+            expect(leftPanel.isGitHistoryContainerVisible()).to.be.false;
+        });
+    });
+
+    describe('outline view UI', () => {
+        const tabName = 'Outline';
+        it('should start with outline view tab already created', () => {
+            expect(rightPanel.doesTabExist(tabName)).to.be.true;
+        });
+        it('should start with outline view not visible', () => {
+            expect(rightPanel.isOutlineViewVisible()).to.be.false;
+        });
+        it('should start with outline view tab not active', () => {
+            expect(rightPanel.isTabActive(tabName)).to.be.false;
+        });
+        it('outline view should toggle-on then toggle-off', () => {
+            if (!rightPanel.isOutlineViewVisible()) {
+                topPanel.toggleOutlineView();
+                rightPanel.waitForOutlineViewVisible();
+            }
+            expect(rightPanel.isOutlineViewVisible()).to.be.true;
+
+            topPanel.toggleOutlineView();
+            expect(rightPanel.isOutlineViewVisible()).to.be.false;
+        });
+    });
+
+    describe('output view UI', () => {
+        it('should start with output view not visible', () => {
+            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        });
+        it('output view should toggle-on then toggle-off', () => {
+            if (!bottomPanel.isOutputViewVisible()) {
+                topPanel.toggleOutputView();
+                bottomPanel.waitForOutputView();
+            }
+            expect(bottomPanel.isOutputViewVisible()).to.be.true;
+            topPanel.toggleOutputView();
+            expect(bottomPanel.isOutputViewVisible()).to.be.false;
+        });
+    });
+
+    describe('plugins view UI', () => {
+        it('should start with plugins view not visible', () => {
+            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        });
+        it('plugins view should toggle-on then toggle-off', () => {
+            if (!bottomPanel.isOutputViewVisible()) {
+                topPanel.toggleOutputView();
+                bottomPanel.waitForOutputView();
+            }
+            expect(bottomPanel.isOutputViewVisible()).to.be.true;
+            topPanel.toggleOutputView();
+            expect(bottomPanel.isOutputViewVisible()).to.be.false;
+        });
+    });
+
+    describe('problems view UI', () => {
+        it('should open a new problems view and then close it', () => {
+            if (!bottomPanel.isProblemsViewVisible()) {
+                topPanel.openProblemsView();
+                bottomPanel.waitForProblemsView();
+            }
+            expect(bottomPanel.isProblemsViewVisible()).to.be.true;
+
+            bottomPanel.closeCurrentView();
+            expect(bottomPanel.isProblemsViewVisible()).to.be.false;
+        });
+    });
+
+    describe('search view UI', () => {
+        it('should start with search view visible', () => {
+            expect(leftPanel.isSearchViewVisible()).to.be.true;
+        });
+        it('search view should toggle-on then toggle-off', () => {
+            if (!leftPanel.isSearchViewVisible()) {
+                topPanel.toggleSearchView();
+                leftPanel.waitForSearchViewVisible();
+            }
+            expect(leftPanel.isSearchViewVisible()).to.be.true;
+            topPanel.toggleSearchView();
+            expect(leftPanel.isSearchViewVisible()).to.be.false;
+        });
+    });
+
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,42 @@
+// copied from https://github.com/theia-ide/theia/blob/master/configs/base.tsconfig.json
+
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+{
+    "compilerOptions": {
+        "skipLibCheck": true,
+        "declaration": true,
+        "declarationMap": true,
+        "noImplicitAny": true,
+        "noEmitOnError": false,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "strictNullChecks": true,
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "downlevelIteration": true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "es5",
+        "jsx": "react",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "sourceMap": true
+    }
+}

--- a/tests/wdio.base.conf.js
+++ b/tests/wdio.base.conf.js
@@ -1,0 +1,327 @@
+// copied from https://github.com/theia-ide/theia/blob/master/examples/browser/wdio.base.conf.js
+
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+ // Based on https://github.com/webdriverio/webdriverio/blob/master/examples/wdio.conf.js
+  /********************************************************************************
+   * Copyright (c) JS Foundation and other contributors
+   *
+   * Permission is hereby granted, free of charge, to any person obtaining
+   * a copy of this software and associated documentation files (the
+   * 'Software'), to deal in the Software without restriction, including
+   * without limitation the rights to use, copy, modify, merge, publish,
+   * distribute, sublicense, and/or sell copies of the Software, and to
+   * permit persons to whom the Software is furnished to do so, subject to
+   * the following conditions:
+   * 
+   * The above copyright notice and this permission notice shall be
+   * included in all copies or substantial portions of the Software.
+   * 
+   * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+   * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   ********************************************************************************/
+
+// @ts-check 
+const http = require('http');
+const path = require('path');
+const temp = require('temp');
+
+const wdioRunnerScript = require.resolve('webdriverio/build/lib/runner.js');
+
+// Remove .track() if you'd like to keep the workspace and other temporary
+// files after running the tests.
+const temptrack = temp.track();
+
+/**
+ * WebdriverIO will execute this current script first to setup the tests,
+ *  and it will re-execute it for every test workers (subprocesses).
+ * This means that if we are to set a random port for Theia's backend in the master process,
+ *  we have to pass the port value to the child processes.
+ * This is done via command line arguments: the following lines fetch the port passed
+ *  to the script, it should be set by the master process for the children,
+ *  but you can also specify it manually by doing `yarn test --theia-port 4000` from
+ *  `examples/browser`.
+ */
+const cliPortKey = '--theia-port';
+const cliPortIndex = process.argv.indexOf(cliPortKey);
+const masterPort = cliPortIndex > -1 ? process.argv[cliPortIndex + 1] : 0; // 0 if master
+if (typeof masterPort === 'undefined') {
+    throw new Error(`${cliPortKey} expects a number as following argument`);
+}
+
+const port = masterPort;
+const host = 'localhost';
+
+function makeConfig(headless) {
+    return {
+        //
+        // ==================
+        // Specify Test Files
+        // ==================
+        // Define which test specs should run. The pattern is relative to the directory
+        // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+        // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+        // directory is where your package.json resides, so `wdio` will be called from there.
+        //
+
+        // this is a very basic test suite that should work on all our Theia applications. 
+        specs: [
+            './main-page/main-page.ui-spec.ts'
+        ],
+        // Patterns to exclude.
+        exclude: [
+            // 'path/to/excluded/files'
+        ],
+        //
+        // ============
+        // Capabilities
+        // ============
+        // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+        // time. Depending on the number of capabilities, WebdriverIO launches several test
+        // sessions. Within your capabilities you can overwrite the spec and exclude options in
+        // order to group specific specs to a specific capability.
+        //
+        // First, you can define how many instances should be started at the same time. Let's
+        // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+        // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+        // files and you set maxInstances to 10, all spec files will get tested at the same time
+        // and 30 processes will get spawned. The property handles how many capabilities
+        // from the same test should run tests.
+        //
+        maxInstances: 10,
+        //
+        // If you have trouble getting all important capabilities together, check out the
+        // Sauce Labs platform configurator - a great tool to configure your capabilities:
+        // https://docs.saucelabs.com/reference/platforms-configurator
+        //
+        capabilities: [{
+            // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+            // grid with only 5 firefox instances available you can make sure that not more than
+            // 5 instances get started at a time.
+            maxInstances: 5,
+            browserName: 'chrome',
+            chromeOptions: {
+                args: headless ? ['--headless', '--disable-gpu'] : [],
+            },
+        }],
+        //
+        // ===================
+        // Test Configurations
+        // ===================
+        // Define all options that are relevant for the WebdriverIO instance here
+        //
+        // By default WebdriverIO commands are executed in a synchronous way using
+        // the wdio-sync package. If you still want to run your tests in an async way
+        // e.g. using promises you can set the sync option to false.
+        sync: true,
+        //
+        // Level of logging verbosity: silent | verbose | command | data | result | error
+        logLevel: 'result',
+        //
+        // Enables colors for log output.
+        coloredLogs: true,
+        //
+        // If you only want to run your tests until a specific amount of tests have failed use
+        // bail (default is 0 - don't bail, run all tests).
+        bail: 0,
+        //
+        // Saves a screenshot to a given path if a command fails.
+        screenshotPath: './errorShots/',
+        //
+        // Set a base URL in order to shorten url command calls. If your url parameter starts
+        // with "/", then the base url gets prepended.
+        baseUrl: `http://${host}:${port}`,
+        //
+        // Default timeout for all waitFor* commands.
+        waitforTimeout: 30000,
+        //
+        // Default timeout in milliseconds for request
+        // if Selenium Grid doesn't send response
+        connectionRetryTimeout: 90000,
+        //
+        // Default request retries count
+        connectionRetryCount: 3,
+        //
+        // Initialize the browser instance with a WebdriverIO plugin. The object should have the
+        // plugin name as key and the desired plugin options as properties. Make sure you have
+        // the plugin installed before running any tests. The following plugins are currently
+        // available:
+        // WebdriverCSS: https://github.com/webdriverio/webdrivercss
+        // WebdriverRTC: https://github.com/webdriverio/webdriverrtc
+        // Browserevent: https://github.com/webdriverio/browserevent
+        // plugins: {
+        //     webdrivercss: {
+        //         screenshotRoot: 'my-shots',
+        //         failedComparisonsRoot: 'diffs',
+        //         misMatchTolerance: 0.05,
+        //         screenWidth: [320,480,640,1024]
+        //     },
+        //     webdriverrtc: {},
+        //     browserevent: {}
+        // },
+        //
+        // Test runner services
+        // Services take over a specific job you don't want to take care of. They enhance
+        // your test setup with almost no effort. Unlike plugins, they don't add new
+        // commands. Instead, they hook themselves up into the test process.
+        services: ['selenium-standalone'],
+        seleniumArgs: {
+            seleniumArgs: ["-port", "4444"],
+            javaArgs: ["-Xmx1024m", "-Djna.nosys=true"],
+            drivers: {
+                chrome: {
+                    version: '2.33'
+                }
+            }
+        },
+        seleniumInstallArgs: {
+            drivers: {
+                chrome: {
+                    version: '2.33'
+                }
+            }
+        },
+        //
+        // Framework you want to run your specs with.
+        // The following are supported: Mocha, Jasmine, and Cucumber
+        // see also: http://webdriver.io/guide/testrunner/frameworks.html
+        //
+        // Make sure you have the wdio adapter package for the specific framework installed
+        // before running any tests.
+        framework: 'mocha',
+        //
+        // Test reporter for stdout.
+        // The only one supported by default is 'dot'
+        // see also: http://webdriver.io/guide/testrunner/reporters.html
+        reporters: ['spec'],
+
+        //
+        // Options to be passed to Mocha.
+        // See the full list at http://mochajs.org/
+        mochaOpts: {
+            ui: 'bdd',
+            compilers: ['ts:ts-node/register'],
+            requires: ['reflect-metadata/Reflect'],
+            watch: 'ts',
+            timeout: 30000,
+        },
+        //
+        // =====
+        // Hooks
+        // =====
+        // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+        // it and to build services around it. You can either apply a single function or an array of
+        // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+        // resolved to continue.
+        //
+        // Gets executed once before all workers get launched.
+        onPrepare: function (config, capabilities) {
+            // Modify process.argv so that the server (which is in the
+            // master process) starts with a temporary directory as the
+            // workspace.
+            const rootDir = temptrack.mkdirSync();
+            const argv = [process.argv[0], 'src-gen/backend/server.js', '--root-dir=' + rootDir];
+            // return require('./src-gen/backend/server')(port, host, argv).then(created => {
+                console.log("argv: " + argv);
+                console.log("wdioRunnerScript:" + wdioRunnerScript);
+                console.log("cliPortKey:" + cliPortKey);
+                console.log("port:" + port);
+                // this.execArgv = [wdioRunnerScript, cliPortKey, created.address().port, '--theia-root-dir', rootDir];
+                this.execArgv = [wdioRunnerScript, cliPortKey, port, '--theia-root-dir', rootDir];
+                // this.server = created;
+            // });
+        },
+        // Gets executed after all workers got shut down and the process is about to exit. It is not
+        // possible to defer the end of the process using a promise.
+        onComplete: function (exitCode) {
+            // if (this.server) {
+                // this.server.close();
+            // }
+        },
+        //
+        // Gets executed just before initialising the webdriver session and test framework. It allows you
+        // to manipulate configurations depending on the capability or spec.
+        // beforeSession: function (config, capabilities, specs) {
+        // },
+        //
+        // Gets executed before test execution begins. At this point you can access all global
+        // variables, such as `browser`. It is the perfect place to define custom commands.
+        // before: function (capabilities, specs) {
+        // },
+        //
+        // Hook that gets executed before the suite starts
+        // beforeSuite: function (suite) {
+        // },
+        //
+        // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+        // beforeEach in Mocha)
+        // beforeHook: function () {
+        // },
+        //
+        // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+        // afterEach in Mocha)
+        // afterHook: function () {
+        // },
+        //
+        // Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+        // beforeTest: function (test) {
+        // },
+        //
+        // Runs before a WebdriverIO command gets executed.
+        // beforeCommand: function (commandName, args) {
+        // },
+        //
+        // Runs after a WebdriverIO command gets executed
+        // afterCommand: function (commandName, args, result, error) {
+        // },
+        //
+        // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+        // afterTest: function (test) {
+        // },
+        //
+        // Hook that gets executed after the suite has ended
+        // afterSuite: function (suite) {
+        //     require("webdriverio");
+        //     var fs = require("fs");
+        //     let result = browser.execute("return window.__coverage__;")
+        //     try {
+        //         if (!fs.existsSync('coverage')) {
+        //             fs.mkdirSync('coverage');
+        //         }
+        //         fs.writeFileSync('coverage/coverage.json', JSON.stringify(result.value));
+        //     } catch (err) {
+        //         console.log(`Error writing coverage ${err}`);
+        //     };
+        // },
+        //
+        // Gets executed after all tests are done. You still have access to all global variables from
+        // the test.
+        // after: function (result, capabilities, specs) {
+        // },
+        //
+        // Gets executed right after terminating the webdriver session.
+        // afterSession: function (config, capabilities, specs) {
+        // },
+    }
+}
+
+exports.makeConfig = makeConfig;

--- a/tests/wdio.conf.js
+++ b/tests/wdio.conf.js
@@ -1,0 +1,24 @@
+// copied from https://github.com/theia-ide/theia/blob/master/examples/browser/wdio.conf.js
+
+/********************************************************************************
+ * Copyright (C) 2017-2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+const wdio = require('./wdio.base.conf.js');
+
+// change to false to run tests in a browser that you can see
+const headlessMode=true;
+
+exports.config = wdio.makeConfig(headlessMode);

--- a/tests/wdio.theia-docker.conf.js
+++ b/tests/wdio.theia-docker.conf.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+
+// tests for the "theia-docker" application
+const wdio = require('./wdio.base.conf.js');
+
+exports.config = wdio.makeConfig(true);
+
+// add here the files containing tests to be run for this
+// application
+exports.config.specs.push('./theia-docker/**/*spec.ts');

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install curl xz-utils
 #Install node and yarn
 #From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile
 
-# gpg keys listed at https://github.com/nodejs/node#release-team
+# gpg keys listed at https://github.com/nodejs/node#release-keys
 RUN set -ex \
   && for key in \
   94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
@@ -18,10 +18,12 @@ RUN set -ex \
   56730D5401028683275BD23C23EFEFE93C4CFFFE \
   77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
   gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
   gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
   gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
   done
+  
 
 ENV NODE_VERSION 8.12.0
 
@@ -49,6 +51,7 @@ RUN set -ex \
   && for key in \
   6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
+  gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
   gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
   gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
   gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \


### PR DESCRIPTION
This commit adds a minimal test suite that validates that the images,
that we build and publish, include a minimally working Theia application.

Until now we relied on the success of an image's build during CI, to
publish it on dockerhub. That's not good, because Theia applications
can sometimes build but not behave correctly or even start.

The UI test suite and related configurations were borrowed from the
main theia repo and slightly adapted. ATM we use only the most basic
test suite, "main-page", that should be applicable to all Theia
applications we run CI on.

This will be enhanced in the future to to add image-specific test
files. For example, see wdio.theia-docker.conf.js, that adds an
extra test file to be run, for the theia-docker image. ATM this second
suite is bogus and just for demonstration purposes.