### PR TITLE
docker full: fixed gpg typo (ubuntu 18.04)

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -23,10 +23,11 @@ RUN set -ex \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
     done
 
 
@@ -56,10 +57,11 @@ RUN set -ex \
     && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
     ; do \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
     done \
     && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \


### PR DESCRIPTION
It is some kind of IPV6-related issue to ipv4 instead.

refs:
- https://github.com/theia-ide/theia-apps/pull/136#discussion_r261685806
- https://github.com/jacobalberty/unifi-docker/issues/64#issuecomment-454961479

thanks @marcdumais-work