### PR TITLE
[theia-go] migrate next to vscode extension

### DIFF
--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -1,41 +1,78 @@
 FROM node:8
 ARG version=latest
-ENV GO_VERSION 1.12
-RUN apt-get update && \
-    apt-get install -y curl && \
-    curl -sS https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH $PATH:/usr/local/go/bin
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
-RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
-    yarn theia build
+RUN yarn --pure-lockfile && \
+    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build && \
+    yarn --production && \
+    yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
+    yarn autoclean --force && \
+    rm -rf ./node_modules/electron && \
+    yarn cache clean
+
 # See : https://github.com/theia-ide/theia-apps/issues/34
 RUN adduser --disabled-password --gecos '' theia && \
     chmod g+rw /home && \
     mkdir -p /home/project && \
+    mkdir -p /home/go && \
+    mkdir -p /home/go-tools && \
     chown -R theia:theia /home/theia && \
-    chown -R theia:theia /home/project;
-EXPOSE 3000
-ENV SHELL /bin/bash
+    chown -R theia:theia /home/project && \
+    chown -R theia:theia /home/go && \
+    chown -R theia:theia /home/go-tools;
 USER theia
-RUN go get -u -v github.com/ramya-rao-a/go-outline && \
-    go get -u -v github.com/acroca/go-symbols && \
-    go get -u -v github.com/nsf/gocode && \
-    go get -u -v github.com/rogpeppe/godef && \
-    go get -u -v golang.org/x/tools/cmd/godoc && \
-    go get -u -v github.com/zmb3/gogetdoc && \
-    go get -u -v golang.org/x/lint/golint && \
-    go get -u -v github.com/fatih/gomodifytags && \
-    go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs && \
-    go get -u -v golang.org/x/tools/cmd/gorename && \
-    go get -u -v sourcegraph.com/sqs/goreturns && \
-    go get -u -v github.com/cweill/gotests/... && \
-    go get -u -v golang.org/x/tools/cmd/guru && \
-    go get -u -v github.com/josharian/impl && \
-    go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
-    go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct && \
-    mkdir -p /home/theia/.go && \
-    echo '{"toolsGopath":"/home/theia/go"}' > /home/theia/.go/go.json
-ENV GOPATH /home/project
-ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]
+
+ENV GO_VERSION=1.12 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    GOROOT=/home/go \
+    GOPATH=/home/go-tools
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+# install Go
+RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.$GOOS-$GOARCH.tar.gz | tar -C /home -xzv && \
+    # install VS Code Go tools: https://github.com/Microsoft/vscode-go/blob/058eccf17f1b0eebd607581591828531d768b98e/src/goInstallTools.ts#L19-L45
+    go get -u -v \
+    github.com/mdempsky/gocode \
+    github.com/uudashr/gopkgs/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    golang.org/x/tools/cmd/guru \
+    golang.org/x/tools/cmd/gorename \
+    github.com/fatih/gomodifytags \
+    github.com/haya14busa/goplay/cmd/goplay \
+    github.com/josharian/impl \
+    github.com/tylerb/gotype-live \
+    github.com/rogpeppe/godef \
+    github.com/zmb3/gogetdoc \
+    golang.org/x/tools/cmd/goimports \
+    github.com/sqs/goreturns \
+    winterdrache.de/goformat/goformat \
+    golang.org/x/lint/golint \
+    github.com/cweill/gotests/... \
+    github.com/alecthomas/gometalinter \
+    honnef.co/go/tools/... \
+    github.com/golangci/golangci-lint/cmd/golangci-lint \
+    github.com/mgechev/revive \
+    github.com/sourcegraph/go-langserver \
+    github.com/go-delve/delve/cmd/dlv \
+    github.com/davidrjenni/reftools/cmd/fillstruct \
+    github.com/godoctor/godoctor && \
+    go get -u -v -d github.com/stamblerre/gocode && \
+    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode && \
+    rm -rf $GOPATH/src && \
+    rm -rf $GOPATH/pkg 
+
+# configure Theia
+ENV SHELL=/bin/bash \
+    THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/plugins  \
+    # configure user Go path
+    GOPATH=/home/project
+ENV PATH=$PATH:$GOPATH/bin
+
+EXPOSE 3000
+ENTRYPOINT [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]

--- a/theia-go-docker/README.md
+++ b/theia-go-docker/README.md
@@ -1,0 +1,12 @@
+## Theia Go Docker
+
+Run on http://localhost:3000 with the current directory as a workspace:
+
+```bash
+docker run --security-opt seccomp=unconfined -e GO111MODULE=auto -it -p 3000:3000 -v "$(pwd):/home/project:cached" theiaide/theia-go:next
+```
+**IMPORTANT**: if your host OS is different from image OS (linux-amd64) then don't mount but pull (`go get`) the project from the container to install dependencies against image OS, otherwise Go tooling won't work properly
+
+Options:
+- `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) to allow Go debugging
+- `-e GO111MODULE=auto` controls [Go module support](https://github.com/golang/go/wiki/Modules#when-do-i-get-old-behavior-vs-new-module-based-behavior)

--- a/theia-go-docker/next.package.json
+++ b/theia-go-docker/next.package.json
@@ -1,22 +1,22 @@
 {
     "private": true,
     "dependencies": {
+        "@theia/plugin-ext-vscode": "next",
+        "@theia/preview": "next",
         "@theia/editor-preview": "next",
-        "@theia/go": "next",
-        "@theia/messages": "next",
-        "@theia/navigator": "next",
-        "@theia/terminal": "next",
-        "@theia/outline-view": "next",
-        "@theia/preferences": "next",
         "@theia/getting-started": "next",
-        "@theia/git": "next",
-        "@theia/file-search": "next",
-        "@theia/markers": "next",
-        "@theia/search-in-workspace": "next",
         "@theia/json": "next",
         "@theia/textmate-grammars": "next"
     },
     "devDependencies": {
-        "@theia/cli": "next"
+        "@theia/cli": "next",
+        "@theia/debug": "next"
+    },
+    "scripts": {
+        "postinstall": "download-debug-adapters"
+    },
+    "adapterDir": "plugins",
+    "adapters": {
+        "vscode-go": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/Go/0.9.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
     }
 }


### PR DESCRIPTION
In order to start one should use:
```
docker run --security-opt seccomp=unconfined -it -p 3000:3000 -v "$(pwd):/home/project:cached" theiaide/theia-go:next
```

It allows ptrace for debugging. When you try it is important to install the project within docker container if you host OS is different.

Debugging https://github.com/demo-apps/go-gin-app:
<img width="2032" alt="Screen Shot 2019-03-12 at 14 16 33" src="https://user-images.githubusercontent.com/3082655/54203145-ead21180-44d1-11e9-9356-62be57e9b62c.png">

Closes #141, fix #118

