### PR TITLE
[full:latest] remove theia-yang-extension

### DIFF
--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -41,8 +41,7 @@
         "@theia/typescript": "latest",
         "@theia/userstorage": "latest",
         "@theia/variable-resolver": "latest",
-        "@theia/workspace": "latest",
-        "theia-yang-extension": "latest"
+        "@theia/workspace": "latest"
     },
     "devDependencies": {
         "@theia/cli": "latest"


### PR DESCRIPTION
ATM it's causing some issues with opening files. We can add
it again once it's adapted to use the version of sprotty that's
hosted at the Eclipse Foundation.

fixes theia-ide/theia#4515 , #142