### PR TITLE
[electron] add missing @theia/electron dependency

### DIFF
--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -33,6 +33,7 @@
         "@theia/callhierarchy": "next",
         "@theia/core": "next",
         "@theia/editor": "next",
+        "@theia/electron": "next",
         "@theia/file-search": "next",
         "@theia/filesystem": "next",
         "@theia/git": "next",


### PR DESCRIPTION
Added missing `@theia/electron` dependency necessary to build the 
`theia-electron` bundled application.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>