### PR TITLE
[Travis] Use node 10 for latest images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ branches:
 language: generic
 
 env:
-  - NPM_TAG=latest IMAGE_NAME=theia-full NODE_VERSION=8.14.1
+  - NPM_TAG=latest IMAGE_NAME=theia-full NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-full NODE_VERSION=10.15.3
-  - NPM_TAG=latest IMAGE_NAME=theia NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=theia NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=theia-java NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=theia-java NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-java NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=theia-go NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=theia-go NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-go NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=yangster NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=yangster NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=yangster NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=theia-python NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=theia-python NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-python NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=theia-swift NODE_VERSION=8
+  - NPM_TAG=latest IMAGE_NAME=theia-swift NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-swift NODE_VERSION=10
 
 install:


### PR DESCRIPTION
Theia switched to supporting node 10 recently, instead of node 8.
That change will be reflected, in published "latest" Theia packages,
once we release 0.6.0; we should then merge this so that the "latest"
images in this repo can be built.

Fixes #171

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>