### PR TITLE
Fix electron language support

### DIFF
--- a/theia-electron/README.md
+++ b/theia-electron/README.md
@@ -4,7 +4,8 @@ The electron-based Theia application with JavaScript/TypeScript and Java support
 
 ----
 
-No downloads yet but you can build one from the `next` Theia. The prerequisites are defined [here](https://github.com/theia-ide/theia/blob/master/doc/Developing.md#prerequisites), plus you need Node.js `8.12.0` due to the [`electron-builder`](https://github.com/electron-userland/electron-builder/commit/c01b7c0b55d3466b826ea9cc9a11ad34118801c1#diff-a8de729869dd8f08fbe76328e6e803d6R16) dependency.
+No downloads yet but you can build one from the `next` Theia.
+The prerequisites are defined [here](https://github.com/theia-ide/theia/blob/master/doc/Developing.md#prerequisites).
 
 Note, we do not save the `yarn.lock` file, so whenever you build a new application, you get the most recent, `next` version of Theia. You can find the bundled application in the `dist` folder.
 

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -55,6 +55,7 @@
         "@theia/search-in-workspace": "next",
         "@theia/task": "next",
         "@theia/terminal": "next",
+        "@theia/textmate-grammars": "next",
         "@theia/typescript": "next",
         "@theia/userstorage": "next",
         "@theia/workspace": "next",
@@ -62,9 +63,9 @@
     },
     "devDependencies": {
         "@theia/cli": "next",
-        "electron-builder": "^20.36.2"
+        "electron-builder": "^20.40.2"
     },
     "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.2.0"
     }
 }


### PR DESCRIPTION
Fixes #173

Fixed the bundled Electron applications which
did not properly start language servers resulting
in missing language support, and features.

- Upgraded `node` version to 10 lts.
- Upgraded `electron-builder` to compatible version with node update.
- Added missing `@theia/textmate-grammars` dependency.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>