### PR TITLE
[theia-electron] Use locally installed Electron

### DIFF
--- a/theia-electron/electron-builder.yml
+++ b/theia-electron/electron-builder.yml
@@ -1,3 +1,4 @@
+electronDist: node_modules/electron/dist
 productName: Theia
 appId: theia
 


### PR DESCRIPTION
This will make sure that the packaged application use the patched
electron binaries pulled by `@theia/electron`.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>