### PR TITLE
WIP [tests] step wdio-mocha-framework to avoid build issue

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -23,7 +23,7 @@
     "ts-node": "<7.0.0",
     "typescript": "3.1.6",
     "wdio-spec-reporter": "0.1.0",
-    "wdio-mocha-framework": "0.5.9",
+    "wdio-mocha-framework": "0.5.13",
     "wdio-selenium-standalone-service": "0.0.8",
     "webdriverio": "4.9.2"
   }


### PR DESCRIPTION
When building the tests (cd tests;yarn) using node 10.x, I get
a failure during the build of one of our native dependency:
fiber@1.0.15. I think it's this issue:
https://github.com/nodejs/node-gyp/issues/1569

In our case, fiber is pulled by wdio-mocha-framework. I stepped
its version to the latest minor available, and now fiber@2.0.2
is pulled, and the build problem is gone.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>