### PR TITLE
Revert "[all] add resolution for vscode-uri@1.0.6"

### DIFF
--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -21,8 +21,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -24,8 +24,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -67,8 +67,5 @@
     },
     "engines": {
         "node": ">=10.2.0"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -44,8 +44,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -51,8 +51,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -16,8 +16,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-go-docker/next.package.json
+++ b/theia-go-docker/next.package.json
@@ -18,8 +18,5 @@
     "adapterDir": "plugins",
     "adapters": {
         "vscode-go": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/Go/0.9.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-java-docker/latest.package.json
+++ b/theia-java-docker/latest.package.json
@@ -17,8 +17,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-java-docker/next.package.json
+++ b/theia-java-docker/next.package.json
@@ -21,8 +21,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -16,8 +16,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-python-docker/next.package.json
+++ b/theia-python-docker/next.package.json
@@ -19,8 +19,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -22,8 +22,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/theia-swift-docker/next.package.json
+++ b/theia-swift-docker/next.package.json
@@ -25,8 +25,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-    },
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
     }
 }

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -22,8 +22,5 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-	},
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
-    }
+	}
 }

--- a/yangster-docker/next.package.json
+++ b/yangster-docker/next.package.json
@@ -26,8 +26,5 @@
     },
     "devDependencies": {
         "@theia/cli": "next"
-	},
-    "resolutions": {
-        "vscode-uri": "<=1.0.6"
-    }
+	}
 }


### PR DESCRIPTION
This reverts commit be26586425b5ec6904ab81be43a0b8836d206e05.

We have a fix, merged in Theia's master branch, that makes
this work-around obsolete. So I am reverting.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>