### PR TITLE
[cpp] Added cpp Docker application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-python NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-swift NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-swift NODE_VERSION=10
+  - NPM_TAG=latest IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
+  - NPM_TAG=next IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
 
 install:
   - cd "$IMAGE_NAME-docker"

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,8 @@
     "test-app-theia-java": "yarn test",
     "test-app-theia-python": "yarn test",
     "test-app-yangster": "yarn test",
-    "test-app-theia-swift": "yarn test"
+    "test-app-theia-swift": "yarn test",
+    "test-app-theia-cpp": "yarn test"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -6,9 +6,14 @@ ARG GITHUB_TOKEN
 ARG NODE_VERSION=10.15.3
 ENV NODE_VERSION $NODE_VERSION
 ENV YARN_VERSION 1.13.0
+
 # use "latest" or "next" version for Theia packages
 ARG version=latest
 
+# Optionally build a striped Theia application with no map file or .ts sources.
+# Makes image ~150MB smaller when enabled
+ARG strip=false
+ENV strip=$strip
 
 #Common deps
 RUN apt-get update && \
@@ -114,10 +119,23 @@ USER theia
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 
-# using "NODE_OPTIONS=..." to avoid out-of-memory problem in CI
-RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
-    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build
+RUN if [ "$strip" = "true" ]; then \
+yarn --pure-lockfile && \
+    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build && \
+    yarn --production && \
+    yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
+    yarn autoclean --force && \
+    yarn cache clean \
+;else \
+yarn --cache-folder ./ycache && rm -rf ./ycache && \
+     NODE_OPTIONS="--max_old_space_size=4096" yarn theia build \
+;fi
+
 EXPOSE 3000
 ENV SHELL /bin/bash
 
-ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]
+ENTRYPOINT [ "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]
+# ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ] 

--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -1,0 +1,123 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG GITHUB_TOKEN
+ARG NODE_VERSION=10.15.3
+ENV NODE_VERSION $NODE_VERSION
+ENV YARN_VERSION 1.13.0
+# use "latest" or "next" version for Theia packages
+ARG version=latest
+
+
+#Common deps
+RUN apt-get update && \
+    apt-get -y install build-essential \
+                       curl \
+                       git \
+                       gpg \
+                       python \
+                       wget \
+                       xz-utils && \
+    rm -rf /var/lib/apt/lists/* 
+
+#Install node and yarn
+#From: https://github.com/nodejs/docker-node/blob/6b8d86d6ad59e0d1e7a94cec2e909cad137a028f/8/Dockerfile
+
+# gpg keys listed at https://github.com/nodejs/node#release-keys
+RUN set -ex \
+    && for key in \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    ; do \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    done
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+
+RUN set -ex \
+    && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+    ; do \
+    gpg --batch --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    done \
+    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+    && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+    && mkdir -p /opt/yarn \
+    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
+    && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+    && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
+    && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+#C/C++ Developer tools
+
+# install clangd and clang-tidy from the public LLVM PPA (nightly build / development version)
+# and also the GDB debugger, cmake from the Ubuntu repos
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y cmake \
+                       clang-tools-9 \
+                       clang-tidy-9 \
+                       gdb && \
+    ln -s /usr/bin/clangd-9 /usr/bin/clangd && \
+    ln -s /usr/bin/clang-tidy-9 /usr/bin/clang-tidy && \
+    rm -rf /var/lib/apt/lists/* 
+
+## User account
+RUN adduser --disabled-password --gecos '' theia
+ADD settings.json /home/theia/.theia/
+
+RUN chmod g+rw /home && \
+    mkdir -p /home/project && \
+    chown -R theia:theia /home/theia && \
+    chown -R theia:theia /home/project;
+
+# Theia application
+
+USER theia
+WORKDIR /home/theia
+ADD $version.package.json ./package.json
+
+# using "NODE_OPTIONS=..." to avoid out-of-memory problem in CI
+RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
+    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build
+EXPOSE 3000
+ENV SHELL /bin/bash
+
+ENTRYPOINT [ "yarn", "theia", "start", "/home/project", "--hostname=0.0.0.0" ]

--- a/theia-cpp-docker/README.md
+++ b/theia-cpp-docker/README.md
@@ -1,0 +1,23 @@
+## Theia cpp Docker
+
+A containerized Theia-based C/C++ demo IDE, including commonly used tools:
+- latest clangd Language Server (nightly build)
+- latest stand-alone clang-tidy static analyser (nightly build)
+- GDB 8.1 (from Ubuntu repo)
+- cmake 3.10.2 (from Ubuntu repo)
+
+The included Theia-based IDE application has the following notable features
+- [@theia/cpp] Language-server built-in clang-tidy static analyser integration. Will analyse files opened in the IDE's editors and report problems for configured rules. See [README](https://github.com/theia-ide/theia/tree/master/packages/cpp#using-the-clang-tidy-linter) for more details, including related preferences
+- [TODO][@theia/cpp-debug] basic C/C++ debugging support
+
+### How to use
+
+Run on http://localhost:3000 with the current directory as a workspace:
+
+```bash
+docker run --security-opt seccomp=unconfined --init -it -p 3000:3000 -v "$(pwd):/home/project:cached" theiaide/theia-cpp:next
+```
+
+Options:
+- `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) to allow cpp debugging
+- `--init` injects an instance of [tini](https://github.com/krallin/tini) in the container, that will wait-for and reap terminated processes, to avoid leaking PIDs.

--- a/theia-cpp-docker/README.md
+++ b/theia-cpp-docker/README.md
@@ -21,3 +21,15 @@ docker run --security-opt seccomp=unconfined --init -it -p 3000:3000 -v "$(pwd):
 Options:
 - `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) to allow cpp debugging
 - `--init` injects an instance of [tini](https://github.com/krallin/tini) in the container, that will wait-for and reap terminated processes, to avoid leaking PIDs.
+
+### How to build
+
+Build image using `next` Theia packages and strip the Theia application to save space (with reduced debuggability) 
+```bash
+docker build --no-cache --build-arg version=next --build-arg strip=true  -t theia-cpp:next .
+```
+
+Build image using `latest` theia packages (Theia app not stripped)
+```bash
+docker build --no-cache --build-arg version=latest --build-arg -t theia-cpp:latest .
+```

--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -1,0 +1,65 @@
+{
+    "private": true,
+    "name": "@theia/cpp-docker-example",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "theia": {
+      "frontend": {
+        "config": {
+          "applicationName": "Theia cpp Example",
+          "preferences": {
+            "files.enableTrash": false
+          }
+        }
+      }
+    },
+    "dependencies": {
+        "@theia/callhierarchy": "latest",
+        "@theia/console": "latest",
+        "@theia/core": "latest",
+        "@theia/cpp": "latest",
+        "@theia/debug": "latest",
+        "@theia/debug-nodejs": "latest",
+        "@theia/editor": "latest",
+        "@theia/editorconfig": "latest",
+        "@theia/editor-preview": "latest",
+        "@theia/file-search": "latest",
+        "@theia/filesystem": "latest",
+        "@theia/getting-started": "latest",
+        "@theia/git": "latest",
+        "@theia/json": "latest",
+        "@theia/keymaps": "latest",
+        "@theia/languages": "latest",
+        "@theia/markers": "latest",
+        "@theia/merge-conflicts": "latest",
+        "@theia/messages": "latest",
+        "@theia/metrics": "latest",
+        "@theia/mini-browser": "latest",
+        "@theia/monaco": "latest",
+        "@theia/navigator": "latest",
+        "@theia/outline-view": "latest",
+        "@theia/output": "latest",
+        "@theia/plantuml": "latest",
+        "@theia/plugin": "latest",
+        "@theia/plugin-ext": "latest",
+        "@theia/plugin-ext-vscode": "latest",
+        "@theia/preferences": "latest",
+        "@theia/preview": "latest",
+        "@theia/process": "latest",
+        "@theia/scm": "latest",
+        "@theia/search-in-workspace": "latest",
+        "@theia/task": "latest",
+        "@theia/terminal": "latest",
+        "@theia/textmate-grammars": "latest",
+        "@theia/tslint": "latest",
+        "@theia/typehierarchy": "latest",
+        "@theia/typescript": "latest",
+        "@theia/userstorage": "latest",
+        "@theia/variable-resolver": "latest",
+        "@theia/workspace": "latest",
+        "typescript": "latest"
+    },
+    "devDependencies": {
+        "@theia/cli": "latest"
+    }
+}

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -1,0 +1,65 @@
+{
+    "private": true,
+    "name": "@theia/cpp-docker-example",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "theia": {
+      "frontend": {
+        "config": {
+          "applicationName": "Theia cpp Example",
+          "preferences": {
+            "files.enableTrash": false
+          }
+        }
+      }
+    },
+    "dependencies": {
+        "@theia/callhierarchy": "next",
+        "@theia/console": "next",
+        "@theia/core": "next",
+        "@theia/cpp": "next",
+        "@theia/debug": "next",
+        "@theia/debug-nodejs": "next",
+        "@theia/editor": "next",
+        "@theia/editorconfig": "next",
+        "@theia/editor-preview": "next",
+        "@theia/file-search": "next",
+        "@theia/filesystem": "next",
+        "@theia/getting-started": "next",
+        "@theia/git": "next",
+        "@theia/json": "next",
+        "@theia/keymaps": "next",
+        "@theia/languages": "next",
+        "@theia/markers": "next",
+        "@theia/merge-conflicts": "next",
+        "@theia/messages": "next",
+        "@theia/metrics": "next",
+        "@theia/mini-browser": "next",
+        "@theia/monaco": "next",
+        "@theia/navigator": "next",
+        "@theia/outline-view": "next",
+        "@theia/output": "next",
+        "@theia/plantuml": "next",
+        "@theia/plugin": "next",
+        "@theia/plugin-ext": "next",
+        "@theia/plugin-ext-vscode": "next",
+        "@theia/preferences": "next",
+        "@theia/preview": "next",
+        "@theia/process": "next",
+        "@theia/search-in-workspace": "next",
+        "@theia/scm": "next",
+        "@theia/task": "next",
+        "@theia/terminal": "next",
+        "@theia/textmate-grammars": "next",
+        "@theia/tslint": "next",
+        "@theia/typehierarchy": "next",
+        "@theia/typescript": "next",
+        "@theia/userstorage": "next",
+        "@theia/variable-resolver": "next",
+        "@theia/workspace": "next",
+        "typescript": "latest"
+    },
+    "devDependencies": {
+        "@theia/cli": "next"
+    }
+}

--- a/theia-cpp-docker/settings.json
+++ b/theia-cpp-docker/settings.json
@@ -1,0 +1,4 @@
+{
+   "cpp.clangTidy": true
+}
+


### PR DESCRIPTION
The image includes the nightly build for clangd and command-line
clang-tidy. Also includes a preference to enable the clang-tidy
integration, where it runs co-located with clangd and can "comment"
about linter issues in open files.

Fixes #194

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>