### PR TITLE
Add 'debug' and 'debug-nodejs' to docker image

### DIFF
--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -2,6 +2,8 @@
     "private": true,
     "dependencies": {
         "@theia/callhierarchy": "latest",
+        "@theia/debug": "latest",
+        "@theia/debug-nodejs": "latest",
         "@theia/file-search": "latest",
         "@theia/git": "latest",
         "@theia/json": "latest",

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -2,6 +2,8 @@
     "private": true,
     "dependencies": {
         "@theia/callhierarchy": "next",
+        "@theia/debug": "next",
+        "@theia/debug-nodejs": "next",
         "@theia/editor-preview": "next",
         "@theia/file-search": "next",
         "@theia/getting-started": "next",


### PR DESCRIPTION
Fixes #106

Added the `@theia/debug` and `@theia/debug-nodejs` dependencies
to the theia-docker image (both `latest` and `next`).

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>