### PR TITLE
[stale] update 'stale.yml' configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,7 +27,7 @@ daysUntilClose: 30
 onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+exemptLabels: ['no-stale', 'help wanted']
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -56,7 +56,7 @@ markComment: >
 #   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 30
+limitPerRun: 5
 
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
- updated the probot stale bot to exempt the labels `no-stale` and `help wanted`
- updated the `limitPerRun` to only run 5 actions per hour

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>