### PR TITLE
[go:latest] Align VS Code extension version with next

### DIFF
--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -36,6 +36,6 @@
     },
     "adapterDir": "plugins",
     "adapters": {
-        "vscode-go": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/Go/0.9.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+        "vscode-go": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/Go/0.11.4/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
     }
 }


### PR DESCRIPTION
One PR added the usage of the VS Code extension to the
latest image while another stepped the version of the
same extension used for next. This third PR steps the
version of the extension used for latest so it matches
the updated next.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>