### PR TITLE
[full] [cpp] Increment clang from version 9 to version 10 for LLVM PP…

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -97,11 +97,11 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
     apt-get install -y cmake \
-                       clang-tools-9 \
-                       clang-tidy-9 \
+                       clang-tools-10 \
+                       clang-tidy-10 \
                        gdb && \
-    ln -s /usr/bin/clangd-9 /usr/bin/clangd && \
-    ln -s /usr/bin/clang-tidy-9 /usr/bin/clang-tidy && \
+    ln -s /usr/bin/clangd-10 /usr/bin/clangd && \
+    ln -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy && \
     rm -rf /var/lib/apt/lists/* 
 
 ## User account

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -118,8 +118,8 @@ RUN apt-get update && apt-get -y install openjdk-8-jdk maven gradle
 # public LLVM PPA, development version of LLVM
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && apt-get install -y clang-tools-9 && \
-    ln -s /usr/bin/clangd-9 /usr/bin/clangd
+    apt-get update && apt-get install -y clang-tools-10 && \
+    ln -s /usr/bin/clangd-10 /usr/bin/clangd
 
 #Python 2
 RUN apt-get update && apt-get install -y python python-pip && \


### PR DESCRIPTION
…A. Resolves issue #223.

Installation proceeds past Step 18/39, with console output:

`The following NEW packages will be installed:
  binfmt-support binutils binutils-common binutils-x86-64-linux-gnu clang-10
  clang-tools-10 file gcc-7-base lib32gcc1 lib32stdc++6 libasan4 libatomic1
  libbinutils libc-dev-bin libc6-dev libc6-i386 libcilkrts5
  libclang-common-10-dev libclang-cpp1-10 libclang1-10 libffi-dev libgc1c2
  libgcc-7-dev libgomp1 libitm1 libllvm10 liblsan0 libmagic-mgc libmagic1
  libmpdec2 libmpx2 libobjc-7-dev libobjc4 libomp-10-dev libomp5-10 libpfm4
  libpipeline1 libpython3-stdlib libpython3.6-minimal libpython3.6-stdlib
  libquadmath0 libstdc++-7-dev libtinfo-dev libtsan0 libubsan0 linux-libc-dev
  llvm-10 llvm-10-dev llvm-10-runtime manpages manpages-dev mime-support
  python3 python3-minimal python3.6 python3.6-minimal`