### PR TITLE
[dart] fix failing CI on theia-dart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
   - NPM_TAG=latest IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
-  - NPM_TAG=latest IMAGE_NAME=theia-dart NODE_VERSION=10.15.3
-  - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10.15.3
+  - NPM_TAG=latest IMAGE_NAME=theia-dart NODE_VERSION=10
+  - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10
 
 install:
   - cd "$IMAGE_NAME-docker"


### PR DESCRIPTION
Fixes #224

Fix the failing CI build for the `theia-dart` image which is caused by the sensitive version of `NODE_VERSION` specified in the `.travis.yml` file. For the line 
`RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash` the `NODE_VERSION` is sensitive to 10 rather than 10.15.3.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>