### PR TITLE
[dart] update reference to 'eclipse/theia-cpp-extension'

### DIFF
--- a/theia-rust-docker/Dockerfile
+++ b/theia-rust-docker/Dockerfile
@@ -20,8 +20,8 @@ ENV THEIA_RUST_APP_PATH /root/theia_rust_app
 RUN mkdir $THEIA_RUST_APP_PATH
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn global add node-gyp
 ADD next.package.json $THEIA_RUST_APP_PATH/package.json
-RUN git clone https://github.com/eclipse/theia-cpp-extension.git /root/theia-cpp-extension
-RUN cp -R /root/theia-cpp-extension/packages $THEIA_RUST_APP_PATH/.
+RUN git clone https://github.com/eclipse-theia/theia-cpp-extensions.git /root/theia-cpp-extensions
+RUN cp -R /root/theia-cpp-extensions/packages $THEIA_RUST_APP_PATH/.
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache 
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH/packages/cpp-debug && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache 
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn theia build


### PR DESCRIPTION
Fixes #227

Since the repository `eclipse/theia-cpp-extension` has been moved and renamed
to `eclipse-theia/theia-cpp-extensions` we need to update the reference in the
repository. This fixes the issue where the rust image cannot find the repo
and build properly as a consequence.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>