### PR TITLE
Clang10

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -98,6 +98,7 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
     apt-get install -y cmake \
                        clang-tools-10 \
+                       clangd-10 \
                        clang-tidy-10 \
                        gdb && \
     ln -s /usr/bin/clangd-10 /usr/bin/clangd && \

--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -97,11 +97,11 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
     apt-get install -y cmake \
-                       clang-tools-9 \
-                       clang-tidy-9 \
+                       clang-tools-10 \
+                       clang-tidy-10 \
                        gdb && \
-    ln -s /usr/bin/clangd-9 /usr/bin/clangd && \
-    ln -s /usr/bin/clang-tidy-9 /usr/bin/clang-tidy && \
+    ln -s /usr/bin/clangd-10 /usr/bin/clangd && \
+    ln -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy && \
     rm -rf /var/lib/apt/lists/* 
 
 ## User account

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -118,8 +118,9 @@ RUN apt-get update && apt-get -y install openjdk-8-jdk maven gradle
 # public LLVM PPA, development version of LLVM
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && apt-get install -y clang-tools-10 && \
-    ln -s /usr/bin/clangd-10 /usr/bin/clangd
+    apt-get update && apt-get install -y clang-tools-10 clangd-10 clang-tidy-10 && \
+    ln -s /usr/bin/clangd-10 /usr/bin/clangd && \
+    ln -s /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
 
 #Python 2
 RUN apt-get update && apt-get install -y python python-pip && \

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -118,8 +118,8 @@ RUN apt-get update && apt-get -y install openjdk-8-jdk maven gradle
 # public LLVM PPA, development version of LLVM
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && apt-get install -y clang-tools-9 && \
-    ln -s /usr/bin/clangd-9 /usr/bin/clangd
+    apt-get update && apt-get install -y clang-tools-10 && \
+    ln -s /usr/bin/clangd-10 /usr/bin/clangd
 
 #Python 2
 RUN apt-get update && apt-get install -y python python-pip && \


### PR DESCRIPTION
**What it does**
Fixes theia-apps/theia-cpp-docker and theia-apps/theia-full-docker
Clang-tools does not include the clangd and clang-tidy as it used too, so updated the Dockerfile to have the clangd and clang-tidy  tools available with those configurations.

**How to test**
Build the docker file for theia-apps/theia-cpp-docker and theia-apps/theia-full-docker
i.e.
```
Build:
docker build --no-cache --build-arg version=next --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t theia-full:next .
Run:
docker run -it -p 3010:3000 --security-opt=seccomp:unconfined -v "$(pwd):/home/project:cached" theia-full:next
```
In the browser, verify the clangd and clang-tidy are available
i.e. 
```
- clangd --version
- clang-tidy --version
```
  
**Review checklist**
 as an author, I have thoroughly tested my changes and carefully followed the review guidelines
**Reminder for reviewers**
as a reviewer, I agree to behave in accordance with the review guidelines
Signed-off-by: Jacques Bouthillier jacques.bouthillier@ericsson.com