### PR TITLE
Correct permissions so that crates can be installed as a non-root user

### DIFF
--- a/theia-rust-docker/Dockerfile
+++ b/theia-rust-docker/Dockerfile
@@ -20,27 +20,34 @@ ENV THEIA_RUST_APP_PATH /root/theia_rust_app
 RUN mkdir $THEIA_RUST_APP_PATH
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn global add node-gyp
 ADD next.package.json $THEIA_RUST_APP_PATH/package.json
-RUN git clone https://github.com/eclipse/theia-cpp-extension.git /root/theia-cpp-extension
+RUN git clone https://github.com/eclipse-theia/theia-cpp-extensions.git /root/theia-cpp-extension
 RUN cp -R /root/theia-cpp-extension/packages $THEIA_RUST_APP_PATH/.
+RUN cp -Rv /root/theia-cpp-extension/dev-packages/* $THEIA_RUST_APP_PATH/packages/.
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache 
-RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH/packages/cpp-debug && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache 
 RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn theia build
 
 # when creating a container a volume is mapped to /root/rust
 # to allow to make persistent changes
+ENV RUST_HOME /root/rust
 ENV RUSTUP_HOME /root/rust/rustup
 ENV CARGO_HOME /root/rust/cargo
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/sh.rustup.rs && sh /tmp/sh.rustup.rs -y
+# ensure that a custom user who's member of the 'rust' group
+# is able to modify CARGO_HOME dir
+RUN mkdir -p $RUST_HOME && \
+    groupadd -g 500 rust && \
+    chown root:rust $RUST_HOME && \
+    chmod g+rwxs $RUST_HOME 
+RUN umask 0002 && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/sh.rustup.rs && sh /tmp/sh.rustup.rs -y
 
 ARG rust_channel=nightly-2019-08-01
 
 # install language server dependencies for theia
-RUN . /root/rust/cargo/env && rustup toolchain install $rust_channel
-RUN . /root/rust/cargo/env && rustup default $rust_channel
-RUN . /root/rust/cargo/env && rustup component add rust-src rust-docs rls rust-analysis rustfmt clippy
+RUN . /root/rust/cargo/env && umask 0002 && rustup toolchain install $rust_channel
+RUN . /root/rust/cargo/env && umask 0002 && rustup default $rust_channel
 
-RUN . /root/rust/cargo/env && cargo +$rust_channel install racer
+RUN . /root/rust/cargo/env && umask 0002 && rustup component add rust-src rust-docs rls rust-analysis rustfmt clippy
+RUN . /root/rust/cargo/env && umask 0002 && cargo +$rust_channel install racer
 
 EXPOSE 3000
 ENV SHELL /bin/bash

--- a/theia-rust-docker/README.md
+++ b/theia-rust-docker/README.md
@@ -49,10 +49,18 @@ eg.
 
 <pre>ex_bash "cargo --list"</pre>
 
+## Persistent changes of Rust environment
+
+When the container is started a named Docker volume is created. This volume stores the Rustup and Cargo folders. You can install libraries etc., these changes will be kept even if you delete your container. If you mess up the Rust environment you can reset the environment by issueing:
+
+<pre>
+docker volume rm rust-cargo-vol
+</pre>
+
 ## Example project
 
 A very simple rust example project is included in the example_project folder. It contains a build task and debug configuration which uses rust-gdb.
 
 ## How does it work?
 
-The ex\* scripts check if a container exists and if so reuses it. If not, the container is created. A command is ran inside the container to create a user corresponding to the user calling the ex script. If ex_theia is ran, the bashrc script is sourced after which the run.sh script is ran inside the container. The bashrc script changes the dir to the same location from which the ex script was ran (via the CONTAINER_START_PATH environment variable). This is done only if the current path is within the users mounted HOME dir. Next the bashrc script sources nvm_setup.sh which activates a specific node version and adds yarn to the path. Lastly it sets up the rust build environment through RUSTUP_HOME and CARGO_HOME. Once the environment is sourced the run.sh script can actually start Theia.
+The ex\* scripts check if a container exists and if so reuses it. If not, the container is created including a named volume (rust-cargo-vol) to store persistent changes to the Rust environment. A command is ran inside the container to create a user corresponding to the user calling the ex script. This user has its umask set to 002 and is added to "rust" group so that the user has write access to the cargo folder (mounted from the named volume). If ex_theia is ran, the bashrc script is sourced after which the run.sh script is ran inside the container. The bashrc script changes the dir to the same location from which the ex script was ran (via the CONTAINER_START_PATH environment variable). This is done only if the current path is within the users mounted HOME dir. Next the bashrc script sources nvm_setup.sh which activates a specific node version and adds yarn to the path. Lastly it sets up the rust build environment through RUSTUP_HOME and CARGO_HOME. Once the environment is sourced the run.sh script can actually start Theia.

--- a/theia-rust-docker/bashrc
+++ b/theia-rust-docker/bashrc
@@ -18,6 +18,10 @@ echo "CONTAINER_START_PATH: $CONTAINER_START_PATH"
 cd "$CONTAINER_START_PATH"
 source $HOME/.bashrc
 source /root/nvm_setup.sh
-export RUSTUP_HOME=/root/rust/rustup
-export CARGO_HOME=/root/rust/cargo
-source /root/rust/cargo/env
+
+# allow writing of the CARGO_HOME dir which is owned
+# by group 'rust'
+# when installing rust crates using cargo keep files
+# group writeable
+umask 002
+source $CARGO_HOME/env

--- a/theia-rust-docker/ex_bash
+++ b/theia-rust-docker/ex_bash
@@ -164,7 +164,7 @@ if [ ! "${CID}" ]; then
           -ti \
           ${ENV_VARIABLES} \
           ${CONTAINER_NAME} \
-          /bin/bash -c "addgroup --gid $USER_GID $USER >/dev/null 2>&1 && adduser --no-create-home --disabled-password --gecos \"\" --uid $USER_UID --gid $USER_GID $USER >/dev/null 2>&1 && usermod -a -G sudo $USER"
+          /bin/bash -c "addgroup --gid $USER_GID $USER >/dev/null 2>&1 && adduser --no-create-home --disabled-password --gecos \"\" --uid $USER_UID --gid $USER_GID $USER >/dev/null 2>&1 && usermod -a -G sudo $USER && usermod -aG plugdev $USER && usermod -aG rust $USER"
 
       CID=$(docker ps -q -f status=running -f name=^/${CONTAINER_NAME}$)
 fi

--- a/theia-rust-docker/makefile
+++ b/theia-rust-docker/makefile
@@ -9,7 +9,7 @@ DOCKER_CONTAINER = theia_rust_container
 BUILD_DIR = build-env
 
 ifeq ($(RUST_CHANNEL),)
-RUST_CHANNEL := nightly-2019-08-01
+RUST_CHANNEL := nightly-2019-08-25
 endif
 
 # build the image using the cache

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -9,7 +9,6 @@
     },
     "dependencies": {
         "@theia/core": "next",
-        "@theia/cpp-debug": "*",
         "@theia/editor": "next",
         "@theia/editorconfig": "next",
         "@theia/editor-preview": "next",
@@ -43,7 +42,9 @@
         "@theia/textmate-grammars": "next",
         "@theia/userstorage": "next",
         "@theia/variable-resolver": "next",
-        "@theia/workspace": "next"
+        "@theia/workspace": "next",
+        "@theia/ext-scripts": "*",
+        "@theia/cpp-debug": "next"
     },
     "devDependencies": {
         "@theia/cli": "next"

--- a/theia-rust-docker/sudoers
+++ b/theia-rust-docker/sudoers
@@ -11,6 +11,8 @@ Defaults	mail_badpass
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 Defaults    env_keep += "CONTAINER_START_PATH"
 Defaults    env_keep += "THEIA_RUST_APP_PATH"
+Defaults    env_keep += "RUSTUP_HOME"
+Defaults    env_keep += "CARGO_HOME"
 
 # Host alias specification
 


### PR DESCRIPTION
There is a problem with the Rust app. Currently the files in the cargo folder are owned by "root". Thus the user is not able to install crates. Even more the cache folder is also not writeable. This causes errors when the RLS wants to cache.

The solution was to add a "rust" group and make all the files in the rust folder (cargo and rustup) part of this group and group writable. When the user creates the container the specific user is created inside the container and added to the rust group. The users umask is set to 0002 so that any changes made to the cargo or cache folders are also group writeable. (Drawback) Note that this will also make all other files created by the user (eg. source code) group writeable.