### PR TITLE
Travis should only build/test images that have changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,18 +32,15 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10
 
 install:
-  - cd "$IMAGE_NAME-docker"
-  - IMAGE="theiaide/$IMAGE_NAME"
-  - IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
-  - echo $IMAGE_TAG
   # this makes it possible to see output of the docker build as it unfolds:
   # from https://stackoverflow.com/questions/43918874/how-to-increase-no-activity-wait-time-in-travis-ci
   - "travis_wait 30 sleep 1800 &"
-  - docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
-  - docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
-  - docker run --init -d -p 0.0.0.0:4000:3000 "$IMAGE_TAG"
+  # check if there were changes since the previous commit in this image
+  # if not (script returns 137) then the build process is terminated
+  - ./check_changed.sh $IMAGE_NAME ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
+  - ./build_container.sh $NPM_TAG $IMAGE_NAME $NODE_VERSION
 
-script: cd ../tests; yarn; yarn test-app-$IMAGE_NAME
+script: cd tests; yarn; yarn test-app-$IMAGE_NAME
 
 after_failure:
   script: cd $TRAVIS_BUILD_DIR && ./commit_screenshots.sh

--- a/build_container.sh
+++ b/build_container.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# this script is called by Travis to build the Docker image
+NPM_TAG=$1
+IMAGE_NAME=$2
+NODEVERSION=$3
+
+cd "$IMAGE_NAME-docker"
+
+IMAGE="theiaide/$IMAGE_NAME"
+IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
+echo $IMAGE_TAG
+docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
+docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
+docker run --init -d -p 0.0.0.0:4000:3000 "$IMAGE_TAG"

--- a/check_changed.sh
+++ b/check_changed.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+# This script is called by Travis during the install step.
+# It returns 1 if no files where changed. In that case
+# no further building/test is required for this image
+
+IMAGE_NAME=$1
+
+echo "Travis event type: $TRAVIS_EVENT_TYPE"
+
+if [ "$TRAVIS_EVENT_TYPE" == "api" ]
+then
+    # trigger via travis dashboard
+    # test all
+    echo "Trigger all tests"
+    exit 0
+fi
+
+cd "$IMAGE_NAME-docker"
+
+CHANGED_FILES=$(git diff --name-status HEAD~1...HEAD .)
+if [ -z "$CHANGED_FILES" ]
+then
+    # nothing changed, skip building
+    echo "No changes in $IMAGE_NAME, terminate"
+   
+    # this indicates to the parent script that the build can be terminated
+    exit 137
+fi
+
+echo "There were changes in $IMAGE_NAME changes: $CHANGED_FILES"
+exit 0


### PR DESCRIPTION
A proposed solution to issue #214. On each commit only those images will be built/tested that were changed.

I used TRAVIS_EVENT_TYPE to determine if the build was started through a commit or via the dashboard (more options -> trigger build)

https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

    If a commit is done only the specific image is built/tested.
    If "trigger build" is clicked via the travis dashboard, all images are built/tested
