### PR TITLE
https and token authentication for theia-ide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
   - NPM_TAG=latest IMAGE_NAME=theia-dart NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10
+  - NPM_TAG=latest IMAGE_NAME=theia-https NODE_VERSION=10 ENV_VARS="-e token=" PORT=10443
+  - NPM_TAG=next IMAGE_NAME=theia-https NODE_VERSION=10 ENV_VARS="-e token=" PORT=10443
 
 install:
   # this makes it possible to see output of the docker build as it unfolds:
@@ -38,7 +40,7 @@ install:
   # check if there were changes since the previous commit in this image
   # if not (script returns 137) then the build process is terminated
   - ./check_changed.sh $IMAGE_NAME ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
-  - ./build_container.sh $NPM_TAG $IMAGE_NAME $NODE_VERSION
+  - ./build_container.sh $NPM_TAG $IMAGE_NAME $NODE_VERSION $PORT $ENV_VARS
 
 script: cd tests; yarn; yarn test-app-$IMAGE_NAME
 

--- a/build_container.sh
+++ b/build_container.sh
@@ -5,6 +5,24 @@ set -e
 NPM_TAG=$1
 IMAGE_NAME=$2
 NODEVERSION=$3
+PORT=${4:-3000}
+shift
+shift
+shift
+[ $# -gt 0 ] && shift
+
+# Theia standard port is listening in port 3000 (the common nodejs port), and it is exposed when running the docker
+# container (-p 0.0.0.0:4000:3000). But some new applications may need to change it (e.g. theia-https-docker).
+# This 4th parameter enables to expose a custom port instead of the common 3000 port. It is set to 3000 as a default
+# value if not included, for backward compatiblity
+PORT=${4:-3000}
+shift
+shift
+shift
+
+# We know that there are at least 3 parameters. If we shift the 4th parameter and it is not set, shift will fail thus
+# failing the script (because of set -e)
+[ $# -gt 0 ] && shift
 
 cd "$IMAGE_NAME-docker"
 
@@ -13,4 +31,7 @@ IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
 echo $IMAGE_TAG
 docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
 docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
-docker run --init -d -p 0.0.0.0:4000:3000 "$IMAGE_TAG"
+
+# Now we allow to pass extra parameters to the docker run command: any extra parameter to build_container.sh is
+# interpreted as a parameter to docker run (it is useful for e.g. passing environment variables or volume mappings)
+docker run --init -d "$@" -p 0.0.0.0:4000:$PORT "$IMAGE_TAG"

--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,8 @@
     "test-app-theia-swift": "yarn test",
     "test-app-theia-cpp": "yarn test",
     "test-app-theia-rust": "yarn test",
-    "test-app-theia-dart": "yarn test"
+    "test-app-theia-dart": "yarn test",
+    "test-app-theia-https": "wdio wdio.theia-https.conf.js --theia-port 4000"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/tests/wdio.theia-https.conf.js
+++ b/tests/wdio.theia-https.conf.js
@@ -1,0 +1,31 @@
+const wdio = require('./wdio.base.conf.js');
+const headless = true;
+
+const config = wdio.makeConfig(headless);
+
+const cliPortKey = '--theia-port';
+const cliPortIndex = process.argv.indexOf(cliPortKey);
+const masterPort = cliPortIndex > -1 ? process.argv[cliPortIndex + 1] : 0; // 0 if master
+if (typeof masterPort === 'undefined') {
+    throw new Error(`${cliPortKey} expects a number as following argument`);
+}
+
+/*  The tests call the url / so we are not able to use the token. 
+    Let's disable the token authentication. Otherwise we'll need to 
+    update every test to add the token: url="/?token=xxxx"
+const cliTokenKey = '--sec-token';
+const cliTokenIndex = process.argv.indexOf(cliTokenKey);
+const token = cliTokenIndex > -1 ? process.argv[cliTokenIndex + 1] : 0; // 0 if master
+if (typeof token === 'undefined') {
+    throw new Error(`${cliTokenKey} expects a string as following argument`);
+} 
+*/
+
+const port = masterPort;
+const host = 'localhost';
+
+if (headless)
+    config.capabilities[0].chromeOptions.args.push('--allow-insecure-localhost');
+
+config.baseUrl = `https://${host}:${port}`;
+exports.config = config;

--- a/theia-https-docker/Dockerfile
+++ b/theia-https-docker/Dockerfile
@@ -1,0 +1,23 @@
+ARG version=latest
+ARG app=theia
+FROM theiaide/$app:$version
+
+# We need to add openssl to be able to create the certificates on demand
+USER root
+RUN (apk update 2> /dev/null && apk add openssl) || (apt-get update 2> /dev/null && apt-get install -y openssl) || (yum install openssl)
+RUN npm install -g gen-http-proxy
+USER theia
+
+# Add our script
+ADD ssl_theia.sh /home/theia/ssl/
+
+ARG LISTEN_PORT=10443
+
+# Set the parameters for the gen-http-proxy
+ENV staticfolder /usr/local/lib/node_modules/gen-http-proxy/static 
+ENV server :$LISTEN_PORT
+ENV target localhost:3000
+ENV secure 1 
+
+# Run theia and accept theia parameters
+ENTRYPOINT [ "/home/theia/ssl/ssl_theia.sh" ]

--- a/theia-https-docker/README.md
+++ b/theia-https-docker/README.md
@@ -1,0 +1,88 @@
+# https and token authentication for theia-ide
+
+[theia-ide](https://hub.docker.com/r/theiaide/theia) is a powerful mechanism for remote development in your servers. The problem is that it has no authentication mechanism, so if anyone knows your server and port, your code will be exposed.
+
+This image adds a security layer for the standard image of theia-ide. It adds **token authentication** and a **https** to make your coding sessions more secure. The security is added by means of [gen-http-proxy](https://www.npmjs.com/package/gen-http-proxy), which is a generic http proxy that enables https and token authentication.
+
+## How to use
+
+Run on https://localhost:10443 with the current directory as a workspace (creating a random token):
+
+```console
+docker run --init -it -p 10443:10443 -v "$(pwd):/home/project:cached" theiaide/theia-https:latest
+generating key file for https
+generating cert file for https
+root INFO Theia app listening on http://localhost:3000.
+redirecting to localhost:3000
+access url: https://0.0.0.0:10443?token=0f34fd329f266caca309bd47f8f8cc6f
+token: 0f34fd329f266caca309bd47f8f8cc6f
+use cookies: true
+expiration: 60
+```
+
+Run on https://localhost:10443 with the current directory as a workspace and the token "_mysecrettoken_":
+
+```console
+docker run --init -it -p 10443:10443 -e token=mysecrettoken -v "$(pwd):/home/project:cached" theiaide/theia-https:latest
+generating key file for https
+generating cert file for https
+root INFO Theia app listening on http://localhost:3000.
+redirecting to localhost:3000
+access url: https://0.0.0.0:10443?token=mysecrettoken
+token: mysecrettoken
+use cookies: true
+expiration: 60
+```
+
+The repository also contains a script called `theiahere` that wraps this command to ease the usage. You are invited to copy it to `/usr/local/bin` to be able to use it from any folder.
+
+## Building your image
+
+This image includes some add-ons to the standard `theia` image. So it adds some layers to a standard theia image. It should be possible to use it to add https and token authentication to _virtually any_ theia docker image (provided that the image makes theia listen at port 3000). 
+
+In order to build the secure image for the standard `theia:latest` docker image, you can simply issue the next command:
+
+```console
+$ docker build . -t theiaide/theia-https:latest
+```
+
+If you want to change other version (e.g. next), you can pass arguments to the build command:
+
+```console
+$ docker build . --build-arg version=next -t theiaide/theia-https:next
+```
+
+If you want to add the security layer to other theia app from the `theiaide` dockerhub repository, you can select the app (e.g. theia-go):
+
+```console
+$ docker build . --build-arg app=theia-go -t theiaide/theia-go-sec
+```
+
+### Customize the security layer
+
+You can customize your server, so that you have a predefined token (instead of generating a random one), disable https, and others. Most of the customization options are provided by means of env variables in **gen-http-proxy**. So you can add commands like `-e secure=0` to your docker run command line for customization.
+
+An example of changing the default port in which listens the secure theia ide is the next:
+
+```
+$ docker run -u $(id -u) --rm -it -p 10080:10080 -e server=:10080 -e secure=0 -v $(pwd):/home/project theiaide/theia-https
+```
+
+In this case, we are disabling https, but keeping token authentication. Moreover we are listening in port 10080.
+
+Other example:
+
+```
+$ docker run -u $(id -u) --rm -it -p 20000:20000 -e server=:20000 -e token=mysecretpassword -v $(pwd):/home/project theiaide/theia-https
+```
+
+In this case we are keeping https (enabled by default), but we are using port 20000. Moreover, we set the token to `mysecretpassword`.
+
+You are invited to take a look at the documentation of **gen-http-proxy** at https://github.com/dealfonso/gen-http-proxy or https://www.npmjs.com/package/gen-http-proxy, to know more about customization options.
+
+## Issues
+
+If you have issues, please report them in the repositories:
+
+- repository for **gen-http-proxy** at github: https://github.com/dealfonso/gen-http-proxy
+- repository for **theia-ide apps** at github: https://github.com/theia-ide/theia-apps

--- a/theia-https-docker/ssl_theia.sh
+++ b/theia-https-docker/ssl_theia.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# sec-theia-ide - add a security layer to theia-ide (https and token authentication)
+#
+# https://github.com/dealfonso/sec-theia-ide
+#
+# Copyright (C) GRyCAP - I3M - UPV
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+FOLDER=${FOLDER:-/tmp/ssl}
+mkdir -p "$FOLDER"
+KEYFILE="${FOLDER}/server.key"
+CERTFILE="${FOLDER}/server.crt"
+DEBUG="${DEBUG:-0}"
+
+secure="${secure:-1}"
+
+if [ "$secure" == "1" ]; then
+
+if [ ! -e "$KEYFILE" ]; then
+  echo "generating key file for https"
+  openssl genrsa -out "$KEYFILE" > /dev/null 2> /dev/null
+  if [ $? -ne 0 ]; then
+    echo "failed to generate key file" >&2
+    exit 1
+  fi
+fi
+
+if [ ! -e "$CERTFILE" ]; then
+  echo "generating cert file for https"
+  openssl req -new -key "$KEYFILE" -x509 -days 365 -out "$CERTFILE" -subj /CN=$HOSTNAME > /dev/null
+  if [ $? -ne 0 ]; then
+    echo "failed to generate cert file" >&2
+    exit 1
+  fi
+fi
+
+fi
+
+if [ "$DEBUG" == "1" ]; then
+    node /home/theia/src-gen/backend/main.js /home/project "$@" &
+else
+    node /home/theia/src-gen/backend/main.js /home/project "$@" 2> /dev/null &
+fi
+
+THEIAPID=$!
+sleep 3s
+if kill -0 $THEIAPID > /dev/null 2> /dev/null; then
+  cert="$CERTFILE" key="$KEYFILE" secure=$secure /usr/local/bin/gen-http-proxy localhost:3000
+  kill $THEIAPID
+else
+  echo "could not spawn theia";
+fi

--- a/theia-https-docker/theiahere
+++ b/theia-https-docker/theiahere
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# theia-https - add a security layer to theia-ide (https and token authentication)
+#
+# https://github.com/theia-ide/theia-apps
+#
+# Copyright (C) GRyCAP - I3M - UPV
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+docker run --rm -it -p 10443:10443 -v $(pwd):/home/project theiaide/theia-https


### PR DESCRIPTION
# https and token authentication for theia-ide

This image adds **token authentication** and **https** to theia, to make your coding sessions more secure. The security is added by means of [gen-http-proxy](https://www.npmjs.com/package/gen-http-proxy), which is a generic http proxy that enables https and token authentication.

## Usage

Run on https://localhost:10443 with the current directory as a workspace (creating a random token):

```console
docker run --init -it -p 10443:10443 -v "$(pwd):/home/project:cached" theiaide/theia-https:latest
generating key file for https
generating cert file for https
root INFO Theia app listening on http://localhost:3000.
redirecting to localhost:3000
access url: https://0.0.0.0:10443?token=0f34fd329f266caca309bd47f8f8cc6f
token: 0f34fd329f266caca309bd47f8f8cc6f
use cookies: true
expiration: 60
```

## https and token authentication for other theia images

It should be possible to use it to add https and token authentication to _virtually any_ theia docker image (provided that the image makes theia listen at port 3000).

**example**

If you want to add the security layer to other theia app from the `theiaide` dockerhub repository, you can select the app (e.g. theia-go):

```console
$ docker build . --build-arg app=theia-go -t theiaide/theia-go-https
```