### PR TITLE
Trigger all builds on api or cron job

### DIFF
--- a/check_changed.sh
+++ b/check_changed.sh
@@ -8,9 +8,9 @@ IMAGE_NAME=$1
 
 echo "Travis event type: $TRAVIS_EVENT_TYPE"
 
-if [ "$TRAVIS_EVENT_TYPE" == "api" ]
+if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]
 then
-    # trigger via travis dashboard
+    # trigger via travis dashboard or cron job
     # test all
     echo "Trigger all tests"
     exit 0


### PR DESCRIPTION
When the nightly cron job runs, this needs to trigger a build for all images. 