### PR TITLE
Fix Travis Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_deploy:
 
 deploy:
   provider: script
-  script: docker push "$IMAGE"
+  script: docker push "theiaide/$IMAGE_NAME"
   on:
     branch: master
   skip_cleanup: true


### PR DESCRIPTION
**Description**

Fixed the failing deployment stage of the Docker images introduced by the following changes https://github.com/theia-ide/theia-apps/pull/236. We used to publish based on `$IMAGE`, yet after refactoring the content to `build_container.sh`, `$IMAGE` is `undefined` and results in a Docker "invalid reference format" error.

Error:

https://travis-ci.org/theia-ide/theia-apps/jobs/594094812#L1071-L1073

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>