### PR TITLE
Fix webdriverio tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ branches:
 
 language: generic
 
+addons:
+  apt:
+    update: true
+    sources:
+    - ubuntu-toolchain-r-test
+    chrome: stable
+
 env:
   - NPM_TAG=latest IMAGE_NAME=theia-full NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-full NODE_VERSION=10.15.3

--- a/tests/wdio.base.conf.js
+++ b/tests/wdio.base.conf.js
@@ -189,14 +189,14 @@ function makeConfig(headless) {
             javaArgs: ["-Xmx1024m", "-Djna.nosys=true"],
             drivers: {
                 chrome: {
-                    version: '2.33'
+                    version: '2.35'
                 }
             }
         },
         seleniumInstallArgs: {
             drivers: {
                 chrome: {
-                    version: '2.33'
+                    version: '2.35'
                 }
             }
         },


### PR DESCRIPTION
Fixes #250

- Fix webdriverio by including `addons` with `chrome:stable`.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>