### PR TITLE
Add 'cpp-debug' dependency

### DIFF
--- a/theia-cpp-docker/README.md
+++ b/theia-cpp-docker/README.md
@@ -8,7 +8,7 @@ A containerized Theia-based C/C++ demo IDE, including commonly used tools:
 
 The included Theia-based IDE application has the following notable features
 - [@theia/cpp] Language-server built-in clang-tidy static analyser integration. Will analyse files opened in the IDE's editors and report problems for configured rules. See [README](https://github.com/theia-ide/theia/tree/master/packages/cpp#using-the-clang-tidy-linter) for more details, including related preferences
-- [TODO][@theia/cpp-debug] basic C/C++ debugging support
+- [@theia/cpp-debug] Basic C/C++ debugging support
 
 ### How to use
 
@@ -24,7 +24,7 @@ Options:
 
 ### How to build
 
-Build image using `next` Theia packages and strip the Theia application to save space (with reduced debuggability) 
+Build image using `next` Theia packages and strip the Theia application to save space (with reduced debuggability)
 ```bash
 docker build --no-cache --build-arg version=next --build-arg strip=true  -t theia-cpp:next .
 ```

--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -18,6 +18,7 @@
         "@theia/console": "latest",
         "@theia/core": "latest",
         "@theia/cpp": "latest",
+        "@theia/cpp-debug": "latest",
         "@theia/debug": "latest",
         "@theia/debug-nodejs": "latest",
         "@theia/editor": "latest",

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -18,6 +18,7 @@
         "@theia/console": "next",
         "@theia/core": "next",
         "@theia/cpp": "next",
+        "@theia/cpp-debug": "next",
         "@theia/debug": "next",
         "@theia/debug-nodejs": "next",
         "@theia/editor": "next",

--- a/theia-cpp-electron/README.md
+++ b/theia-cpp-electron/README.md
@@ -46,6 +46,3 @@ $> yarn theia start /home/user/workspace
 ```
 
 If you wish to package your application, you might take inspiration from the `theia-electron` [example](https://github.com/theia-ide/theia-apps/tree/master/theia-electron).
-
-### Coming soon
-- Basic debugging using GDB, provided by `@theia/cpp-debug`

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -35,6 +35,7 @@
     "@theia/console": "latest",
     "@theia/core": "latest",
     "@theia/cpp": "latest",
+    "@theia/cpp-debug": "latest",
     "@theia/debug": "latest",
     "@theia/debug-nodejs": "latest",
     "@theia/editor": "latest",


### PR DESCRIPTION
Fixes #227

- added `@theia/cpp-debug` dependency to the `theia-cpp-docker:latest` image.
- added `@theia/cpp-debug` dependency to the `theia-cpp-docker:next` image.
- added `@theia/cpp-debug` dependency to the `theia-cpp-electron` application.
- updated documentation present in the `theia-cpp-docker` readme.
- updated documentation present in the `theia-cpp-electron` readme.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>