### PR TITLE
Update 'stalebot' to only check 'question' labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,7 +24,7 @@ daysUntilStale: 60
 daysUntilClose: 30
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: []
+onlyLabels: ['question']
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels: ['no-stale', 'help wanted']


### PR DESCRIPTION
**Description**

Update the `stalebot` config to only verify issues which have the `question` label. Now that https://github.com/probot/stale/pull/213 is fixed, we can turn stalebot on with the initial plan of only
verifying issues which have a certain type of label.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>