### PR TITLE
Add support for dark theme on macOS

### DIFF
--- a/theia-electron/electron-builder.yml
+++ b/theia-electron/electron-builder.yml
@@ -17,6 +17,7 @@ win:
 mac:
   target:
     - dmg
+  darkModeSupport: true
 linux:
   target:
     - deb


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #267
- adds support for _macOS_ dark theme for the electron window.
- adds support for _macOS_ dark theme for the electron native menus.

| Light Window | Dark Window |
|:---:|:---:|
| <img width="1205" alt="Screen Shot 2019-11-13 at 8 42 11 AM" src="https://user-images.githubusercontent.com/40359487/68769403-3a815380-05f2-11ea-9911-707cb11453f6.png"> |<img width="1205" alt="Screen Shot 2019-11-13 at 8 42 34 AM" src="https://user-images.githubusercontent.com/40359487/68769423-440abb80-05f2-11ea-8ebd-37595e16bef9.png"> |

| Light Menu | Dark Menu |
|:---:|:---:|
| <img width="456" alt="Screen Shot 2019-11-13 at 8 45 03 AM" src="https://user-images.githubusercontent.com/40359487/68769492-669cd480-05f2-11ea-8685-4f5c2d90948f.png">| <img width="456" alt="Screen Shot 2019-11-13 at 8 44 26 AM" src="https://user-images.githubusercontent.com/40359487/68769505-6b618880-05f2-11ea-88cd-6b0d4e8f654e.png"> |


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- use macOS
- follow the instructions from https://github.com/theia-ide/theia-apps/blob/master/theia-electron/README.md on how to build and package electron
- start the electron application
- change the theme from the `system preferences` from light to dark and dark to light and verify if the Theia application adjusts accordingly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>