### PR TITLE
Fix JSON language server features

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+
+[*.{js,ts,md}]
+indent_size = 4
+
+[*.{json,yml}]
+indent_size = 4

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,13 @@
+{
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "[typescript]": {
+        "editor.tabSize": 4
+    },
+    "[json]": {
+        "editor.tabSize": 4
+    },
+    "[jsonc]": {
+        "editor.tabSize": 4
+    }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "EditorConfig.EditorConfig",
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "editor.formatOnSave": true,
+    "editor.insertSpaces": true,
+    "[typescript]": {
+        "editor.tabSize": 4
+    },
+    "[json]": {
+        "editor.tabSize": 4
+    },
+    "[jsonc]": {
+        "editor.tabSize": 4
+    }
+}

--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -62,7 +62,8 @@
     },
     "resolutions": {
       "vscode-languageserver-protocol": "3.15.0-next.9",
-      "vscode-languageserver-types": "3.15.0-next.5"
+      "vscode-languageserver-types": "3.15.0-next.5",
+      "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -4,14 +4,14 @@
     "version": "0.0.1",
     "license": "Apache-2.0",
     "theia": {
-      "frontend": {
-        "config": {
-          "applicationName": "Theia C/C++ Example",
-          "preferences": {
-            "files.enableTrash": false
-          }
+        "frontend": {
+            "config": {
+                "applicationName": "Theia C/C++ Example",
+                "preferences": {
+                    "files.enableTrash": false
+                }
+            }
         }
-      }
     },
     "dependencies": {
         "@theia/callhierarchy": "next",
@@ -61,8 +61,9 @@
         "typescript": "latest"
     },
     "resolutions": {
-      "vscode-languageserver-protocol": "3.15.0-next.9",
-      "vscode-languageserver-types": "3.15.0-next.5"
+        "vscode-languageserver-protocol": "3.15.0-next.9",
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
     },
     "devDependencies": {
         "@theia/cli": "next"

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -82,7 +82,8 @@
   },
   "resolutions": {
     "vscode-languageserver-protocol": "3.15.0-next.9",
-    "vscode-languageserver-types": "3.15.0-next.5"
+    "vscode-languageserver-types": "3.15.0-next.5",
+    "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
   },
   "devDependencies": {
     "@theia/cli": "latest"

--- a/theia-dart-docker/latest.package.json
+++ b/theia-dart-docker/latest.package.json
@@ -33,7 +33,8 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
       },
     "scripts": {
         "postinstall": "download-debug-adapters"

--- a/theia-dart-docker/next.package.json
+++ b/theia-dart-docker/next.package.json
@@ -24,7 +24,8 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
       },
     "scripts": {
         "postinstall": "download-debug-adapters"

--- a/theia-deb-build-docker/package.json
+++ b/theia-deb-build-docker/package.json
@@ -3,44 +3,45 @@
     "version": "0.0.1",
     "license": "EPL-2.0",
     "description": "A custom Theia debian package",
-    "engines" : {
-	"node":"10.x"
+    "engines": {
+        "node": "10.x"
     },
     "dependencies": {
-	"@theia/callhierarchy": "latest",
-	"@theia/file-search": "latest",
-	"@theia/json": "latest",
-	"@theia/markers": "latest",
-	"@theia/merge-conflicts": "latest",
-	"@theia/messages": "latest",
-	"@theia/mini-browser": "latest",
-	"@theia/navigator": "latest",
-	"@theia/outline-view": "latest",
-	"@theia/preferences": "latest",
-	"@theia/preview": "latest",
-	"@theia/search-in-workspace": "latest",
-	"@theia/terminal": "latest",
-	"@theia/textmate-grammars": "latest",
-	"typescript": "latest"
+        "@theia/callhierarchy": "latest",
+        "@theia/file-search": "latest",
+        "@theia/json": "latest",
+        "@theia/markers": "latest",
+        "@theia/merge-conflicts": "latest",
+        "@theia/messages": "latest",
+        "@theia/mini-browser": "latest",
+        "@theia/navigator": "latest",
+        "@theia/outline-view": "latest",
+        "@theia/preferences": "latest",
+        "@theia/preview": "latest",
+        "@theia/search-in-workspace": "latest",
+        "@theia/terminal": "latest",
+        "@theia/textmate-grammars": "latest",
+        "typescript": "latest"
     },
     "devDependencies": {
-	"@theia/cli": "latest"
-	},
-	"resolutions": {
-		"vscode-languageserver-protocol": "3.15.0-next.9",
-		"vscode-languageserver-types": "3.15.0-next.5"
-	  },
+        "@theia/cli": "latest"
+    },
+    "resolutions": {
+        "vscode-languageserver-protocol": "3.15.0-next.9",
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "scripts": {
-	"prebuild-deb": "npm install -g node-deb",
-	"build-deb": "node-deb -- ."
+        "prebuild-deb": "npm install -g node-deb",
+        "build-deb": "node-deb -- ."
     },
     "node_deb": {
-	"init":"none",
-	"dependencies": "nodejs (>= 10.0.0)",
-	"install_strategy":"copy",
-	"executable_name": "theia",
-	"entrypoints": {
-	    "cli": "run_theia.sh"
-	}
+        "init": "none",
+        "dependencies": "nodejs (>= 10.0.0)",
+        "install_strategy": "copy",
+        "executable_name": "theia",
+        "entrypoints": {
+            "cli": "run_theia.sh"
+        }
     }
 }

--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -34,8 +34,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -34,10 +34,11 @@
         "@theia/tslint": "next",
         "typescript": "latest"
     },
-      "resolutions": {
+    "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -67,8 +67,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "engines": {
         "node": ">=10.2.0"
     }

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -57,8 +57,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -63,8 +63,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -33,8 +33,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "scripts": {
         "postinstall": "download-debug-adapters"
     },

--- a/theia-go-docker/next.package.json
+++ b/theia-go-docker/next.package.json
@@ -24,8 +24,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "scripts": {
         "postinstall": "download-debug-adapters"
     },

--- a/theia-java-docker/latest.package.json
+++ b/theia-java-docker/latest.package.json
@@ -28,8 +28,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/theia-java-docker/next.package.json
+++ b/theia-java-docker/next.package.json
@@ -31,8 +31,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -26,8 +26,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/theia-python-docker/next.package.json
+++ b/theia-python-docker/next.package.json
@@ -29,8 +29,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }

--- a/theia-rpm-build-docker/package.json
+++ b/theia-rpm-build-docker/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "theia",
-  "version": "0.0.1",
-  "license": "EPL-2.0",
-  "engines" : {
-	  "node":"10.x"
-  },
-  "dependencies": {
-      "@theia/callhierarchy": "latest",
-      "@theia/file-search": "latest",
-      "@theia/json": "latest",
-      "@theia/markers": "latest",
-      "@theia/merge-conflicts": "latest",
-      "@theia/messages": "latest",
-      "@theia/mini-browser": "latest",
-      "@theia/navigator": "latest",
-      "@theia/outline-view": "latest",
-      "@theia/preferences": "latest",
-      "@theia/preview": "latest",
-      "@theia/search-in-workspace": "latest",
-      "@theia/terminal": "latest",
-      "@theia/textmate-grammars": "latest",
-      "typescript": "latest"
-  },
-  "devDependencies": {
-      "@theia/cli": "latest"
-  },
-  "resolutions": {
-    "vscode-languageserver-protocol": "3.15.0-next.9",
-    "vscode-languageserver-types": "3.15.0-next.5"
-  },
-  "scripts": {
-      "prebuild": "npm install -g yarn",
-      "prebuild-rpm": "ln -s \"$( pwd )\" ~/rpmbuild && npm install -g speculate",
-      "build-rpm": "speculate && rpmbuild -bb SPECS/theia.spec",
-      "start": "npm run prebuild && yarn theia start"
-  },
-  "spec": {
-    "rebuild": false,
-    "prune": false,
-    "nodeVersion": "> 10.0.0",
-    "requires": [
-      "nodejs",
-      "python"
-    ],
-    "executable": [
-      "./run_theia.sh"
-    ],
-    "post": [
-      "mv /usr/lib/theia/run_theia.sh /usr/local/bin/theia"
-    ]
-  }
+    "name": "theia",
+    "version": "0.0.1",
+    "license": "EPL-2.0",
+    "engines": {
+        "node": "10.x"
+    },
+    "dependencies": {
+        "@theia/callhierarchy": "latest",
+        "@theia/file-search": "latest",
+        "@theia/json": "latest",
+        "@theia/markers": "latest",
+        "@theia/merge-conflicts": "latest",
+        "@theia/messages": "latest",
+        "@theia/mini-browser": "latest",
+        "@theia/navigator": "latest",
+        "@theia/outline-view": "latest",
+        "@theia/preferences": "latest",
+        "@theia/preview": "latest",
+        "@theia/search-in-workspace": "latest",
+        "@theia/terminal": "latest",
+        "@theia/textmate-grammars": "latest",
+        "typescript": "latest"
+    },
+    "devDependencies": {
+        "@theia/cli": "latest"
+    },
+    "resolutions": {
+        "vscode-languageserver-protocol": "3.15.0-next.9",
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
+    "scripts": {
+        "prebuild": "npm install -g yarn",
+        "prebuild-rpm": "ln -s \"$( pwd )\" ~/rpmbuild && npm install -g speculate",
+        "build-rpm": "speculate && rpmbuild -bb SPECS/theia.spec",
+        "start": "npm run prebuild && yarn theia start"
+    },
+    "spec": {
+        "rebuild": false,
+        "prune": false,
+        "nodeVersion": "> 10.0.0",
+        "requires": [
+            "nodejs",
+            "python"
+        ],
+        "executable": [
+            "./run_theia.sh"
+        ],
+        "post": [
+            "mv /usr/lib/theia/run_theia.sh /usr/local/bin/theia"
+        ]
+    }
 }
-

--- a/theia-ruby-docker/latest.package.json
+++ b/theia-ruby-docker/latest.package.json
@@ -26,8 +26,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -48,12 +48,13 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     },
     "workspaces": [
-      "packages/*"
+        "packages/*"
     ]
 }

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -2,14 +2,14 @@
     "private": true,
     "theia": {
         "frontend": {
-          "config": {
-            "applicationName": "Theia Swift Example",
-            "preferences": {
-              "files.enableTrash": false
+            "config": {
+                "applicationName": "Theia Swift Example",
+                "preferences": {
+                    "files.enableTrash": false
+                }
             }
-          }
         }
-      },
+    },
     "dependencies": {
         "@theia/callhierarchy": "latest",
         "@theia/file-search": "latest",
@@ -32,8 +32,9 @@
         "typescript": "latest"
     },
     "resolutions": {
-      "vscode-languageserver-protocol": "3.15.0-next.9",
-      "vscode-languageserver-types": "3.15.0-next.5"
+        "vscode-languageserver-protocol": "3.15.0-next.9",
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-swift-docker/next.package.json
+++ b/theia-swift-docker/next.package.json
@@ -35,8 +35,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -33,8 +33,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "latest"
     }

--- a/yangster-docker/next.package.json
+++ b/yangster-docker/next.package.json
@@ -36,8 +36,9 @@
     },
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5"
-      },
+        "vscode-languageserver-types": "3.15.0-next.5",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+    },
     "devDependencies": {
         "@theia/cli": "next"
     }


### PR DESCRIPTION
#### What it does

Fixes #271
Fixes #233

- fixes issue where JSON language server did not provide content assist
- fixes issue where JSON language server did not provide hover information
- fixes issue where JSON language server did not generate markers
- similar fix provided by the main repository eclipse-theia/theia#6607

🏅 Bonus:
- added `.editorconfig` file to have consistent formatting across the repo
- added `settings.json` for development through Theia
- added `setting.json` and `extensions.json` for development through VS Code


#### How to test
1. build and run an image
2. open the `preferences` widget
3. determine if the file has content assist, validation, hover info

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>