### PR TITLE
[yangster][full] fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-java NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-go NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-go NODE_VERSION=10
-  - NPM_TAG=latest IMAGE_NAME=yangster NODE_VERSION=10
-  - NPM_TAG=next IMAGE_NAME=yangster NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-python NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-python NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-swift NODE_VERSION=10

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -58,7 +58,6 @@
         "@theia/userstorage": "next",
         "@theia/variable-resolver": "next",
         "@theia/workspace": "next",
-        "theia-yang-extension": "next",
         "typescript": "latest"
     },
     "resolutions": {


### PR DESCRIPTION
Due to limited resources the yangster-related extensions may not keep-up
with the latest Theia platform at all times. To minimize CI issues here,
this commit removes the theia-yangster image (both latest and next) from
CI, and also removes theia-yangs-extension from theia-full:next.

Fixes #294

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>