### PR TITLE
[Theia-Full-Docker] Add YAML support to @next

### DIFF
--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -58,6 +58,7 @@
         "@theia/userstorage": "next",
         "@theia/variable-resolver": "next",
         "@theia/workspace": "next",
+        "@theia/yaml": "next",
         "typescript": "latest"
     },
     "resolutions": {


### PR DESCRIPTION
Adds `@theia/yaml@next` to `theiaide/theia-full:next` which at the moment does not have support for YAML files.

Refs #135 