### PR TITLE
increase node memory size when building

### DIFF
--- a/theia-java-docker/Dockerfile
+++ b/theia-java-docker/Dockerfile
@@ -26,7 +26,7 @@ ARG version=latest
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
 RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
-    yarn theia build ; \
+    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build ; \
     yarn theia download:plugins
 EXPOSE 3000
 ENV SHELL=/bin/bash \

--- a/theia-python-docker/Dockerfile
+++ b/theia-python-docker/Dockerfile
@@ -34,7 +34,7 @@ ARG version=latest
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
 RUN yarn --cache-folder ./ycache && rm -rf ./ycache && \
-    yarn theia build ; \
+     NODE_OPTIONS="--max_old_space_size=4096" yarn theia build ; \
     yarn theia download:plugins
 EXPOSE 3000
 ENV SHELL=/bin/bash \

--- a/theia-ruby-docker/Dockerfile
+++ b/theia-ruby-docker/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
 RUN yarn --cache-folder ./ycache && rm -rf ./ycache
-RUN yarn theia build && yarn theia download:plugins
+RUN NODE_OPTIONS="--max_old_space_size=4096" yarn theia build ; \
+    yarn theia download:plugins
 EXPOSE 3000
 ENV SHELL=/bin/bash \
     THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/plugins


### PR DESCRIPTION
#### What it does

Fixes #317

This commit increases the `node` memory size when building the application in the `theia-java`, `theia-python` and `theia-ruby` images. The same [change](https://github.com/theia-ide/theia-apps/search?q=--max_old_space_size&unscoped_q=--max_old_space_size) was done for other images already.

#### How to test

- the `theia-java` full and latest images should successfully build (verify CI)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>