### PR TITLE
rust: remove rust from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-swift NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
-  - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
+  # skip the `rust` CI build due to known failures: https://github.com/theia-ide/theia-apps/issues/253
+  # - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
   - NPM_TAG=latest IMAGE_NAME=theia-dart NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-https NODE_VERSION=10 ENV_VARS="-e token=" PORT=10443


### PR DESCRIPTION
This commit removes `rust` from CI since it is somewhat fragile, and fails with the same error from the past: https://github.com/theia-ide/theia-apps/issues/253

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

---

@dwjbosman are you fine with the following approach? It looks like rust fails to build due to the same issue regarding the channel date. We can always add back CI for rust if/when the image becomes more stable.