### PR TITLE
Pin vscode-json-languageserver to 1.2.2

### DIFF
--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -54,6 +54,7 @@
         "@theia/workspace": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -54,6 +54,7 @@
         "@theia/workspace": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -75,6 +75,7 @@
         "find-git-repositories": "0.1.1"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-dart-docker/latest.package.json
+++ b/theia-dart-docker/latest.package.json
@@ -31,6 +31,7 @@
         "@theia/debug": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-dart-docker/next.package.json
+++ b/theia-dart-docker/next.package.json
@@ -31,6 +31,7 @@
         "@theia/debug": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-deb-build-docker/package.json
+++ b/theia-deb-build-docker/package.json
@@ -25,6 +25,7 @@
         "@theia/cli": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -35,6 +35,7 @@
         "@theia/cli": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -35,6 +35,7 @@
         "@theia/cli": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -74,6 +74,7 @@
         "The resolution for `fs-extra` was required due to this: https://spectrum.chat/theia/general/our-theia-electron-builder-app-no-longer-starts~f5cf09a0-6d88-448b-8818-24ad0ec2ee7c"
     ],
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -48,6 +48,7 @@
         "@theia/workspace": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -49,6 +49,7 @@
         "@theia/workspace": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -97,6 +97,7 @@
         "vscode-go": "https://github.com/microsoft/vscode-go/releases/download/0.12.0/Go-0.12.0.vsix"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-go-docker/next.package.json
+++ b/theia-go-docker/next.package.json
@@ -97,6 +97,7 @@
         "vscode-go": "https://github.com/microsoft/vscode-go/releases/download/0.12.0/Go-0.12.0.vsix"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-java-docker/latest.package.json
+++ b/theia-java-docker/latest.package.json
@@ -96,6 +96,7 @@
         "vscode-java-dependency-viewer": "https://github.com/microsoft/vscode-java-dependency/releases/download/0.6.0/vscode-java-dependency-0.6.0.vsix"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-java-docker/next.package.json
+++ b/theia-java-docker/next.package.json
@@ -96,6 +96,7 @@
         "vscode-java-dependency-viewer": "https://github.com/microsoft/vscode-java-dependency/releases/download/0.6.0/vscode-java-dependency-0.6.0.vsix"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -28,6 +28,7 @@
         "@theia/terminal": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-python-docker/next.package.json
+++ b/theia-python-docker/next.package.json
@@ -28,6 +28,7 @@
         "@theia/terminal": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-rpm-build-docker/package.json
+++ b/theia-rpm-build-docker/package.json
@@ -24,6 +24,7 @@
         "@theia/cli": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-ruby-docker/latest.package.json
+++ b/theia-ruby-docker/latest.package.json
@@ -30,6 +30,7 @@
         "@theia/terminal": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-ruby-docker/next.package.json
+++ b/theia-ruby-docker/next.package.json
@@ -30,6 +30,7 @@
         "@theia/terminal": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5"
     },

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -45,6 +45,7 @@
         "@theia/cpp-debug": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -29,6 +29,7 @@
         "@theia/terminal": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/theia-swift-docker/next.package.json
+++ b/theia-swift-docker/next.package.json
@@ -29,6 +29,7 @@
         "@theia/terminal": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -30,6 +30,7 @@
         "typescript": "latest"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"

--- a/yangster-docker/next.package.json
+++ b/yangster-docker/next.package.json
@@ -32,6 +32,7 @@
         "theia-yang-extension": "next"
     },
     "resolutions": {
+        "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"


### PR DESCRIPTION
1.2.3 seems to cause incompatibities.

Fixes #333

Signed-off-by: Jérome Perrin <jerome@nexedi.com>