### PR TITLE
[CI] [Rust] Add-back the Rust image to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ env:
   - NPM_TAG=next IMAGE_NAME=theia-swift NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
   - NPM_TAG=next IMAGE_NAME=theia-cpp NODE_VERSION=10.15.3
-  # skip the `rust` CI build due to known failures: https://github.com/theia-ide/theia-apps/issues/253
-  # - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
+  - NPM_TAG=next IMAGE_NAME=theia-rust NODE_VERSION=10.15.3
   - NPM_TAG=latest IMAGE_NAME=theia-dart NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-dart NODE_VERSION=10
   - NPM_TAG=latest IMAGE_NAME=theia-https NODE_VERSION=10 ENV_VARS="-e token=" PORT=10443

--- a/theia-rust-docker/Dockerfile
+++ b/theia-rust-docker/Dockerfile
@@ -23,8 +23,10 @@ ADD next.package.json $THEIA_RUST_APP_PATH/package.json
 RUN git clone https://github.com/eclipse-theia/theia-cpp-extensions.git /root/theia-cpp-extension
 RUN cp -R /root/theia-cpp-extension/packages $THEIA_RUST_APP_PATH/.
 RUN cp -Rv /root/theia-cpp-extension/dev-packages/* $THEIA_RUST_APP_PATH/packages/.
-RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache 
-RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn theia build
+RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn --cache-folder $THEIA_RUST_APP_PATH/ycache && \
+    . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn theia build && \
+    . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn theia download:plugins && \
+    rm -rf $THEIA_RUST_APP_PATH/ycache
 
 # when creating a container a volume is mapped to /root/rust
 # to allow to make persistent changes
@@ -40,7 +42,7 @@ RUN mkdir -p $RUST_HOME && \
     chmod g+rwxs $RUST_HOME 
 RUN umask 0002 && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/sh.rustup.rs && sh /tmp/sh.rustup.rs -y
 
-ARG rust_channel=nightly-2020-04-10
+ARG rust_channel=nightly
 
 # install language server dependencies for theia
 RUN . /root/rust/cargo/env && umask 0002 && rustup toolchain install $rust_channel
@@ -51,6 +53,8 @@ RUN . /root/rust/cargo/env && umask 0002 && cargo +$rust_channel install racer
 
 EXPOSE 3000
 ENV SHELL /bin/bash
+ENV THEIA_DEFAULT_PLUGINS=local-dir:/root/theia_rust_app/plugins
+
 # script to start theia
 ADD run.sh /root/run.sh
 # script to set environment
@@ -60,4 +64,3 @@ RUN chmod 755 /root \
 WORKDIR $THEIA_RUST_APP_PATH
 ENV USER root
 CMD [ "bash", "-rcfile", "/root/bashrc", "-i", "/root/run.sh" ]
-

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -10,7 +10,6 @@
     "dependencies": {
         "@theia/core": "next",
         "@theia/editor": "next",
-        "@theia/editorconfig": "next",
         "@theia/editor-preview": "next",
         "@theia/file-search": "next",
         "@theia/filesystem": "next",


### PR DESCRIPTION
We've been having issues for a while with the Rust image in CI. We're temporarily removed it so that CI can pass, but would like to being it back when the issues are fixed. 

For a while, it looked like the Rust tools were causing the CI issue. A recent update seems to have remove this problem: https://github.com/theia-ide/theia-apps/pull/330#issuecomment-611981825 . So I thought I would give it a try and see what other issues there might be. 

In addition to adding the image back into CI, this PR:
- Removes deprecated @theia/editorconfig (prevented app from starting, though it compiled)
- Adds environment variable so that plugins (VS Code extensions) defined  in package.json are detected/used
