### PR TITLE
[next][cpp] switch to vscode-clangd language client

### DIFF
--- a/theia-cpp-docker/README.md
+++ b/theia-cpp-docker/README.md
@@ -1,16 +1,19 @@
-## Theia cpp Docker
+# Theia cpp Docker
 
 A containerized Theia-based C/C++ demo IDE, including commonly used tools:
+
 - latest clangd Language Server (nightly build)
 - latest stand-alone clang-tidy static analyser (nightly build)
 - GDB 8.1 (from Ubuntu repo)
-- cmake 3.10.2 (from Ubuntu repo)
+- cmake 3.17.0
 
 The included Theia-based IDE application has the following notable features
-- [@theia/cpp] Language-server built-in clang-tidy static analyser integration. Will analyse files opened in the IDE's editors and report problems for configured rules. See [README](https://github.com/theia-ide/theia/tree/master/packages/cpp#using-the-clang-tidy-linter) for more details, including related preferences
+
+- [deprecated][latest][@theia/cpp] Language-server built-in clang-tidy static analyser integration. Will analyse files opened in the IDE's editors and report problems for configured rules. See [README](https://github.com/theia-ide/theia/tree/master/packages/cpp#using-the-clang-tidy-linter) for more details, including related preferences. Note: this LSP client is _deprecated_ and will be replaced once `vscode-clangd` works well with _latest_ Theia
+- [next][vscode-clangd] The reference [Language Client for clangd](https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd)
 - [@theia/cpp-debug] Basic C/C++ debugging support
 
-### How to use
+## How to use
 
 Run on http://localhost:3000 with the current directory as a workspace:
 
@@ -19,17 +22,20 @@ docker run --security-opt seccomp=unconfined --init -it -p 3000:3000 -v "$(pwd):
 ```
 
 Options:
-- `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) to allow cpp debugging
+
+- `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) to allow cpp debugging. Note: anecdotally I am able to debug without this option now. I am not sure what may have changed recently.
 - `--init` injects an instance of [tini](https://github.com/krallin/tini) in the container, that will wait-for and reap terminated processes, to avoid leaking PIDs.
 
-### How to build
+## How to build
 
 Build image using `next` Theia packages and strip the Theia application to save space (with reduced debuggability)
+
 ```bash
 docker build --no-cache --build-arg version=next --build-arg strip=true  -t theia-cpp:next .
 ```
 
 Build image using `latest` theia packages (Theia app not stripped)
+
 ```bash
 docker build --no-cache --build-arg version=latest --build-arg -t theia-cpp:latest .
 ```

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -17,7 +17,6 @@
         "@theia/callhierarchy": "next",
         "@theia/console": "next",
         "@theia/core": "next",
-        "@theia/cpp": "next",
         "@theia/cpp-debug": "next",
         "@theia/debug": "next",
         "@theia/editor": "next",
@@ -56,8 +55,6 @@
     },
     "resolutions": {
         "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
     },
     "devDependencies": {
@@ -126,6 +123,7 @@
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
+        "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.0.21/file/llvm-vs-code-extensions.vscode-clangd-0.0.21.vsix",
         "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
     }
 }


### PR DESCRIPTION
We can only do this change for `next` at the moment because some recently merged features are required to run `vscode-clangd` in Theia applications. We can do `latest` after this month's release.

- remove `@theia/cpp`
- add `vscode-clangd` 
- README update


![image](https://user-images.githubusercontent.com/25749063/79616918-38a54a00-80d4-11ea-996f-40490fa11e51.png)

![image](https://user-images.githubusercontent.com/25749063/79617515-b0c03f80-80d5-11ea-995d-2e41cbcc621a.png)


Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>