### PR TITLE
[cpp-electron] update app to use vscode-clangd for C/C++

### DIFF
--- a/theia-cpp-electron/README.md
+++ b/theia-cpp-electron/README.md
@@ -1,30 +1,30 @@
-## Theia C/C++ Electron Example
+# Theia C/C++ Electron Example
 
-Build an Electron C/C++ Theia IDE, from the Eclipse Theia platform, using the `package.json` present in this folder. Electron applications are a good
-choice for local development.
+One can build an Electron (desktop) Theia example application for C/C++ development, using the `package.json` present in this folder. Electron applications are a good choice for local development but not good for Cloud.
 
-### Install dependencies
+## Install dependencies
 
-#### 1. Theia development dependencies
+### 1. Theia development dependencies
+
 See [here](https://github.com/theia-ide/theia/blob/master/doc/Developing.md#prerequisites) for dependencies you'll need to build a Theia application.
 
-#### 2. clangd
+### 2. clangd
+
 You will need to install the [clangd](https://clang.llvm.org/extra/clangd/Installation.html) language server.
 
-By default, the `clangd` executable is assumed to be named the same and be in the system's path. You can configure an alternate name using the preference `cpp.clangdExecutable`.
+By default, the `clangd` executable is assumed to be named the same and be in the system's path. You can configure an alternate name using the preference `clangd.path`.
 
-If you wish to provide startup arguments to `clangd`, use the preference `cpp.clangdArgs`.
+If you wish to provide startup arguments to `clangd`, use the preference `clangd.arguments`.
 
-You may override the default value of preferences by editing the `preferences` entry in `package.json`.
+## Configurations
 
-### Configurations
+### clang-tidy integration
 
-#### clang-tidy integration
-If you wish to use the [clang-tidy linter integration](https://github.com/theia-ide/theia/blob/master/packages/cpp/README.md#using-the-clang-tidy-linter), you will need to install clangd version 9 or higher, that has a built-in `clang-tidy`, that can provide diagnostics in your Theia editor as you type. You also need to enable the integration using the `cpp.clangTidy` preference.
+If you wish to use the clang_tidy linter integration you will need to install clangd version 9 or higher which has a built-in clang-tidy available. This will provide diagnostics in your Theia editor as you type.
 
-#### @theia/cpp
-The C/C++ features are provided by the `@theia/cpp` extension. Look [here](https://github.com/theia-ide/theia/blob/master/packages/cpp/README.md) for more details about this extension.
+### vscode-clangd
 
+This application uses the [vscode-clangd](https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd) VS Code extension. You can find related preferences under "clangd" in the running application.
 
 ### Build
 

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -27,14 +27,14 @@
         }
     },
     "scripts": {
-        "build": "yarn theia rebuild:electron; yarn theia build",
-        "start": "yarn theia start"
+        "build": "yarn theia rebuild:electron; yarn theia build; yarn download:plugins",
+        "start": "yarn theia start --plugins=local-dir:./plugins",
+        "download:plugins": "theia download:plugins"
     },
     "dependencies": {
         "@theia/callhierarchy": "latest",
         "@theia/console": "latest",
         "@theia/core": "latest",
-        "@theia/cpp": "latest",
         "@theia/cpp-debug": "latest",
         "@theia/debug": "latest",
         "@theia/editor": "latest",
@@ -76,8 +76,6 @@
     },
     "resolutions": {
         "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
         "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
     },
     "devDependencies": {
@@ -146,6 +144,7 @@
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix"
     }
 }


### PR DESCRIPTION
Replacing @theia-cpp, that will soon be deprecated.
    
As well updated the scripts in `package.json` so that the
vscode extensions are downloaded during build and used when
starting the example application.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>