### PR TITLE
bug: fix momentjs dependency

### DIFF
--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -58,7 +58,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-dart-docker/latest.package.json
+++ b/theia-dart-docker/latest.package.json
@@ -35,7 +35,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {

--- a/theia-deb-build-docker/package.json
+++ b/theia-deb-build-docker/package.json
@@ -28,7 +28,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "scripts": {
         "prebuild-deb": "npm install -g node-deb",

--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -39,7 +39,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -52,7 +52,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -101,6 +101,7 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     }
 }

--- a/theia-java-docker/latest.package.json
+++ b/theia-java-docker/latest.package.json
@@ -100,7 +100,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-php-docker/latest.package.json
+++ b/theia-php-docker/latest.package.json
@@ -89,6 +89,7 @@
     "resolutions": {
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     }
 }

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -32,7 +32,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-rpm-build-docker/package.json
+++ b/theia-rpm-build-docker/package.json
@@ -27,7 +27,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "scripts": {
         "prebuild": "npm install -g yarn",

--- a/theia-ruby-docker/latest.package.json
+++ b/theia-ruby-docker/latest.package.json
@@ -33,7 +33,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -33,7 +33,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -101,5 +102,6 @@
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"    }
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+    }
 }

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -33,7 +33,8 @@
         "vscode-json-languageserver": "1.2.2",
         "vscode-languageserver-protocol": "3.15.0-next.9",
         "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #354 

The following pull-request fixes the breaking changes caused by **momentjs**  which ultimately results in the main-menu not being rendered successfully. The fix includes adding `resolutions` to the `latest` images only since `next` are fixed by the upstream change: https://github.com/eclipse-theia/theia/pull/7727

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. run any of the docker images (ex: theia-java) and confirm that the main-menu exists.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

