### PR TITLE
Fix for build failing at go linter

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -107,7 +107,7 @@ RUN go get -u -v github.com/mdempsky/gocode && \
     go get -u -v github.com/cweill/gotests/... && \
     go get -u -v github.com/alecthomas/gometalinter && \
     go get -u -v honnef.co/go/tools/... && \
-    go get -u -v github.com/golangci/golangci-lint/cmd/golangci-lint && \
+    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint && \
     go get -u -v github.com/mgechev/revive && \
     go get -u -v github.com/sourcegraph/go-langserver && \
     go get -u -v github.com/go-delve/delve/cmd/dlv && \


### PR DESCRIPTION
Fix for the build failing at the go linter "go get" on line 110.  Inspiration for the fix came from this thread [https://github.com/golangci/golangci-lint/issues/1037](https://github.com/golangci/golangci-lint/issues/1037) in the golangci repo itself where others were having a similar issue.

- changed go get in line 110 to use go modules.