### PR TITLE
rust: remove racer and use vscode ext

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,8 @@ indent_style = space
 
 [*.{json, md}]
 indent_size = 4
+
+# Makefiles require tabs to run successfully.
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/theia-rust-docker/Dockerfile
+++ b/theia-rust-docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -yq \
-    && apt-get install curl gnupg build-essential gcc g++ gdb make python sudo git -yq 
+    && apt-get install curl gnupg build-essential gcc g++ gdb make python sudo git -yq
 
 # allow a user to become root in the container
 ADD sudoers /etc/sudoers
@@ -39,7 +39,7 @@ ENV CARGO_HOME /root/rust/cargo
 RUN mkdir -p $RUST_HOME && \
     groupadd -g 500 rust && \
     chown root:rust $RUST_HOME && \
-    chmod g+rwxs $RUST_HOME 
+    chmod g+rwxs $RUST_HOME
 RUN umask 0002 && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/sh.rustup.rs && sh /tmp/sh.rustup.rs -y
 
 ARG rust_channel=nightly
@@ -49,7 +49,7 @@ RUN . /root/rust/cargo/env && umask 0002 && rustup toolchain install $rust_chann
 RUN . /root/rust/cargo/env && umask 0002 && rustup default $rust_channel
 
 RUN . /root/rust/cargo/env && umask 0002 && rustup component add rust-src rust-docs rls rust-analysis rustfmt clippy
-RUN . /root/rust/cargo/env && umask 0002 && cargo +$rust_channel install racer
+# RUN . /root/rust/cargo/env && umask 0002 && cargo +$rust_channel install racer
 
 EXPOSE 3000
 ENV SHELL /bin/bash

--- a/theia-rust-docker/makefile
+++ b/theia-rust-docker/makefile
@@ -14,36 +14,35 @@ endif
 
 # build the image using the cache
 image:
-    docker build --build-arg rust_channel=$(RUST_CHANNEL) -t $(DOCKER_IMAGE) .
+	docker build --build-arg rust_channel=$(RUST_CHANNEL) -t $(DOCKER_IMAGE) .
 
 # This empty directory '$(BUILD_DIR)' exists in git, with only an .gitignore file, set to ignore the entire contents of the dir.
 # This helps to avoid committing files in that dir to git.
 rm-files:
-    cd $(BUILD_DIR) && \
-    find . ! -name '.gitignore' -type f -exec rm -f {} + && \
-    find . ! -name '.gitignore' -type d -exec rm -rf {} + > /dev/null 2>&1 ; \
-    exit 0
+	cd $(BUILD_DIR) && \
+	find . ! -name '.gitignore' -type f -exec rm -f {} + && \
+	find . ! -name '.gitignore' -type d -exec rm -rf {} + > /dev/null 2>&1 ; \
+	exit 0
 
 get-files: rm-files
-    # Add these archived files from external sources to the current directory.
-    # Docker will automatically extract them, during image building, with the ADD command.
-    echo "none required"
+	# Add these archived files from external sources to the current directory.
+	# Docker will automatically extract them, during image building, with the ADD command.
+	echo "none required"
 
 clean-image: rm-files get-files
-    docker build --no-cache --build-arg rust_channel=${RUST_CHANNEL} -t $(DOCKER_IMAGE) .
-
+	docker build --no-cache --build-arg rust_channel=${RUST_CHANNEL} -t $(DOCKER_IMAGE) .
 
 # push in a local registry
 push:
-    docker tag ${DOCKER_IMAGE} ${REGISTRY}/${DOCKER_IMAGE}
-    docker push ${REGISTRY}/${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${REGISTRY}/${DOCKER_IMAGE}
+	docker push ${REGISTRY}/${DOCKER_IMAGE}
 
 # pull from a registry
 pull:
-    docker pull ${REGISTRY}/${DOCKER_IMAGE}
-    docker tag ${REGISTRY}/${DOCKER_IMAGE} ${DOCKER_IMAGE}
+	docker pull ${REGISTRY}/${DOCKER_IMAGE}
+	docker tag ${REGISTRY}/${DOCKER_IMAGE} ${DOCKER_IMAGE}
 
 # transfer from remote registry into local registry
 transfer_remote:
-    docker pull ${REGISTRY_REMOTE}/${DOCKER_IMAGE}
-    docker tag ${REGISTRY_REMOTE}/${DOCKER_IMAGE} ${DOCKER_IMAGE}
+	docker pull ${REGISTRY_REMOTE}/${DOCKER_IMAGE}
+	docker tag ${REGISTRY_REMOTE}/${DOCKER_IMAGE} ${DOCKER_IMAGE}

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -119,6 +119,7 @@
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "vscode-rls": "https://github.com/rust-lang/rls-vscode/releases/download/v0.7.8/rust.vsix"
     }
 }


### PR DESCRIPTION
**Description**:

The following pull-request fixes the `rust` build issues by adding the [vscode-rls](https://github.com/rust-lang/rls-vscode) vscode extension and remove the dependency to `racer` which is currently flaky and unnecessary to run the extension.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>