### PR TITLE
Adding support for ppc64le platform

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG GITHUB_TOKEN
 ARG NODE_VERSION=10.15.3
+ARG LLVM=11
 ENV NODE_VERSION $NODE_VERSION
 ENV YARN_VERSION 1.13.0
 
@@ -97,12 +98,12 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
     apt-get install -y \
-                       clang-tools-11 \
-                       clangd-11 \
-                       clang-tidy-11 \
+                       clang-tools-$LLVM \
+                       clangd-$LLVM \
+                       clang-tidy-$LLVM \
                        gdb && \
-    ln -s /usr/bin/clangd-11 /usr/bin/clangd && \
-    ln -s /usr/bin/clang-tidy-11 /usr/bin/clang-tidy && \
+    ln -s /usr/bin/clangd-$LLVM /usr/bin/clangd && \
+    ln -s /usr/bin/clang-tidy-$LLVM /usr/bin/clang-tidy && \
     rm -rf /var/lib/apt/lists/*
 
 # Install latest stable CMake

--- a/theia-cpp-docker/README.md
+++ b/theia-cpp-docker/README.md
@@ -44,3 +44,4 @@ docker build --no-cache --build-arg version=latest --build-arg -t theia-cpp:late
 
 #### Build Options:
   - `--build-arg strip=true` strips the application to save space but with reduced debuggability.
+  - `--build-arg LLVM=<version>` version of LLVM tools (clang-tools, clangd and clang-tidy) you prefer (defaults to 11). Please set LLVM=9 to build on ppc64le platform.


### PR DESCRIPTION
This PR is to add ppc64le support. We are downgrading the versions of the tools clang-tools-11, clangd-11 and clang-tidy-11 to clang-tools-9, clangd-9 and clang-tidy-9. As per https://apt.llvm.org that provides list of clang packages available for different platforms, clang-tools-9, clangd-9 and clang-tidy-9 are the latest versions that support POWER platform.

Signed-off-by: sailaja Chavali sachav83@in.ibm.com