### PR TITLE
Added Travis CI jobs to publish installers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ branches:
   only:
   - master
 
-language: generic
+language: node_js
+node_js: "10"
 
 addons:
   apt:
     update: true
     sources:
     - ubuntu-toolchain-r-test
+    packages: libxkbfile-dev
     chrome: stable
 
 env:
@@ -40,10 +42,21 @@ env:
   - NPM_TAG=latest IMAGE_NAME=theia-php NODE_VERSION=10
   - NPM_TAG=next IMAGE_NAME=theia-php NODE_VERSION=10
 
+jobs:
+  # add installer builds to jobs matrix
+  include:
+    - &publish
+      env:
+      install: skip
+      script: cd theia-electron && yarn && yarn package
+      deploy: skip
+    - <<: *publish
+      os: osx
+    - <<: *publish
+      os: windows
+
 before_install:
-- nvm install 10
-- nvm use 10
-- npm install -g eclint
+- npm install -g yarn eclint
 - eclint check "**/*" || echo "Warning! Formatting errors encountered..."
 
 install:

--- a/build_container.sh
+++ b/build_container.sh
@@ -24,7 +24,7 @@ cd "$IMAGE_NAME-docker"
 IMAGE="theiaide/$IMAGE_NAME"
 IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
 echo $IMAGE_TAG
-docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GITHUB_TOKEN" . -t "$IMAGE_TAG" --no-cache
+docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GH_TOKEN" . -t "$IMAGE_TAG" --no-cache
 docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
 
 # Now we allow to pass extra parameters to the docker run command: any extra parameter to build_container.sh is

--- a/commit_screenshots.sh
+++ b/commit_screenshots.sh
@@ -19,9 +19,9 @@ SOURCE_BRANCH="master"
 # the screenshots will be committed in this branch
 TARGET_BRANCH="bugs"
 
-# Add the GITHUB_TOKEN to the url so that travis is able to commit
+# Add the GH_TOKEN to the url so that travis is able to commit
 REPO=`git config remote.origin.url`
-AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_TOKEN}@github.com/}
+AUTH_REPO=${REPO/https:\/\/github.com\//https://${GH_TOKEN}@github.com/}
 SHA=`git rev-parse --verify HEAD`
 
 git config user.name "Travis CI"

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
-    "name": "theia-electron",
-    "version": "0.1.0",
+    "name": "theia-electron-example",
+    "version": "1.2.0",
     "description": "Theia",
     "main": "scripts/theia-electron-main.js",
     "engines": {
@@ -9,10 +9,15 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/theia-ide/theia.git"
+        "url": "git+https://github.com/theia-ide/theia-apps.git"
     },
     "theia": {
         "target": "electron",
+        "frontend": {
+          "config": {
+            "applicationName": "Theia Electron Example Application"
+          }
+        }, 
         "backend": {
             "config": {
                 "startupTimeout": -1
@@ -31,41 +36,41 @@
     "author": "typefox <npm@typefox.io>",
     "license": "Apache-2.0",
     "bugs": {
-        "url": "https://github.com/theia-ide/theia/issues"
+        "url": "https://github.com/theia-ide/theia-apps/issues"
     },
-    "homepage": "https://github.com/theia-ide/theia#readme",
+    "homepage": "https://github.com/theia-ide/theia-apps#readme",
     "dependencies": {
-        "@theia/callhierarchy": "next",
-        "@theia/core": "next",
-        "@theia/editor": "next",
-        "@theia/electron": "next",
-        "@theia/file-search": "next",
-        "@theia/filesystem": "next",
-        "@theia/getting-started": "next",
-        "@theia/git": "next",
-        "@theia/json": "next",
-        "@theia/keymaps": "next",
-        "@theia/languages": "next",
-        "@theia/markers": "next",
-        "@theia/messages": "next",
-        "@theia/mini-browser": "next",
-        "@theia/monaco": "next",
-        "@theia/navigator": "next",
-        "@theia/outline-view": "next",
-        "@theia/output": "next",
-        "@theia/plugin-ext": "next",
-        "@theia/plugin-ext-vscode": "next",
-        "@theia/preferences": "next",
-        "@theia/preview": "next",
-        "@theia/process": "next",
-        "@theia/search-in-workspace": "next",
-        "@theia/task": "next",
-        "@theia/terminal": "next",
-        "@theia/userstorage": "next",
-        "@theia/workspace": "next"
+        "@theia/callhierarchy": "latest",
+        "@theia/core": "latest",
+        "@theia/editor": "latest",
+        "@theia/electron": "latest",
+        "@theia/file-search": "latest",
+        "@theia/filesystem": "latest",
+        "@theia/getting-started": "latest",
+        "@theia/git": "latest",
+        "@theia/json": "latest",
+        "@theia/keymaps": "latest",
+        "@theia/languages": "latest",
+        "@theia/markers": "latest",
+        "@theia/messages": "latest",
+        "@theia/mini-browser": "latest",
+        "@theia/monaco": "latest",
+        "@theia/navigator": "latest",
+        "@theia/outline-view": "latest",
+        "@theia/output": "latest",
+        "@theia/plugin-ext": "latest",
+        "@theia/plugin-ext-vscode": "latest",
+        "@theia/preferences": "latest",
+        "@theia/preview": "latest",
+        "@theia/process": "latest",
+        "@theia/search-in-workspace": "latest",
+        "@theia/task": "latest",
+        "@theia/terminal": "latest",
+        "@theia/userstorage": "latest",
+        "@theia/workspace": "latest"
     },
     "devDependencies": {
-        "@theia/cli": "next",
+        "@theia/cli": "latest",
         "electron-builder": "^22.4.1",
         "bufferutil": "4",
         "utf-8-validate": "5"
@@ -75,9 +80,9 @@
     ],
     "resolutions": {
         "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
+        "vscode-languageserver-protocol": "3.15.0",
+        "vscode-languageserver-types": "3.15.0",
+        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0",
         "**/fs-extra": "^4.0.3"
     },
     "theiaPluginsDir": "plugins",


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

This PR introduces electron builds and publishing from TravisCI for the master branch.

I've already created a test publish of the installers here: https://github.com/theia-ide/theia-apps/releases/tag/v0.1.0

__Note:__ These installer binaries are untested and currently unsigned. I will create a separate PR later to introduce signing for macOS and Windows.

## Changes

- Added Travis CI jobs to build installers for macOS/Windows/Linux in addition to existing docker jobs which only run on master
- Updated `theia-electron` project to use `latest` theia by default to be more stable for users
- Updated git repository URLs in `theia-electron` project to point at this repo (as it's used by electron-builder for publishing)
- Automatic publishing of installers to GitHub when a draft release exists matching the current version
- Addition of an [entry to the wiki](https://github.com/theia-ide/theia-apps/wiki/Publishing-a-release) which outlines how to publish a release

## Decisions to confirm
- theia tag to use for a release (currently this uses what is set in the `package.json` file which is `latest` and __not__ `next` nor an explicit version)
- publishing is done on GitHub (should it be elsewhere?)
- publishing is to the `theia-apps` repo and not `eclipse-theia`
- do we need to consider different release channels in future?

__Notes:__ 

- Merging this PR should automatically add binaries to a release that has been drafted for `v1.2.0`.
- There is a build error for [theia-next builds](https://travis-ci.org/github/theia-ide/theia-apps/builds/695292595) on master which I believe is unrelated to these changes

cc @akosyakov @marcdumais-work 