### PR TITLE
[full] Add Swift SDK to full image

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Many applications in the repository now include support for running VS Code exte
 
 - #### Build Options:
     - `--init` injects an instance of [tini](https://github.com/krallin/tini) in the container, that will wait-for and reap terminated processes, to avoid leaking PIDs.
-    - `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) for debugging.
+    - `--security-opt seccomp=unconfined` enables running without [the default seccomp profile](https://docs.docker.com/engine/security/seccomp/) for debugging. This option is also required if the swift REPL is needed.
 
 ## Contributing
 

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -166,6 +166,30 @@ RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y \
     && rustup component add rls rust-src rust-analysis
 
 
+#Swift
+ARG SWIFT_VERSION=5.2.4
+
+RUN apt-get update \
+    && apt-get install -y binutils libc6-dev libcurl4 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 pkg-config tzdata zlib1g-dev \
+    && curl -SLO https://swift.org/builds/swift-$SWIFT_VERSION-release/ubuntu1804/swift-$SWIFT_VERSION-RELEASE/swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz \
+    && curl -SLO https://swift.org/builds/swift-$SWIFT_VERSION-release/ubuntu1804/swift-$SWIFT_VERSION-RELEASE/swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz.sig \
+    && wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - \
+    && (    gpg --keyserver pool.sks-keyservers.net --refresh-keys Swift \
+         || gpg --keyserver ipv4.pool.sks-keyservers.net --refresh-keys Swift \
+         || gpg --keyserver pool.sks-keyservers.net --refresh-keys Swift \
+         || gpg --keyserver pgp.mit.edu --refresh-keys Swift \
+         || gpg --keyserver keyserver.pgp.com --refresh-keys Swift \
+         || gpg --keyserver ha.pool.sks-keyservers.net --refresh-keys Swift \
+       ) \
+    && gpg --verify swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz.sig \
+    && tar fxz swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz \
+    && rm swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz swift-$SWIFT_VERSION-RELEASE-ubuntu18.04.tar.gz.sig \
+    && mv swift-$SWIFT_VERSION-RELEASE-ubuntu18.04 /usr/local/swift \
+    && ln -s /usr/local/swift/usr/bin/swift* /usr/bin \
+    && ln -s /usr/local/swift/usr/bin/lldb* /usr/bin \
+    && ln -s /usr/local/swift/usr/bin/sourcekit-lsp /usr/bin
+
+
 # Dart
 ENV DART_VERSION 2.8.4
 


### PR DESCRIPTION
Add swift language tools to full image. If you want to use the swift REPL, these options have to be provided to docker: --cap-add=SYS_PTRACE --security-opt seccomp=unconfined