### PR TITLE
[ci] Skip before_deploy for installer builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
       env:
       install: skip
       script: cd theia-electron && yarn && yarn package
+      before_deploy: skip
       deploy: skip
     - <<: *publish
       os: osx


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

This PR fixes an oversight in the recent travis changes to stop docker commands during a build job for the installers.
