### PR TITLE
Ignore deploy for installers and add timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,7 @@ jobs:
     - &publish
       env:
       install: skip
-      script: cd theia-electron && yarn && yarn package
-      before_deploy: skip
-      deploy: skip
+      script: cd theia-electron && yarn && travis_wait 30 yarn package
     - <<: *publish
       os: osx
     - <<: *publish
@@ -82,6 +80,7 @@ deploy:
   script: docker push "theiaide/$IMAGE_NAME"
   on:
     branch: master
+    condition: $IMAGE_NAME
   skip_cleanup: true
 
 notifications:


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR fixes the failing build in master by skipping the `deploy` step for installers based on environment variables rather than skipping the stage.

It also introduces a timeout for when macOS installer generation takes longer than 10 minutes and is timed out.

Apologies for the oversight, Travis-CI is a [bit weird](https://travis-ci.community/t/unable-to-skip-deploy/9042).