### PR TITLE
json: replace json extension with vscode ext

### DIFF
--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -25,7 +25,6 @@
         "@theia/filesystem": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/keymaps": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
@@ -52,13 +51,6 @@
         "@theia/variable-resolver": "latest",
         "@theia/vsx-registry": "latest",
         "@theia/workspace": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -88,6 +80,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -44,7 +44,6 @@
         "@theia/filesystem": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/keymaps": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
@@ -74,10 +73,6 @@
         "nsfw": "1.2.5",
         "find-git-repositories": "0.1.1"
     },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1"
-    },
     "devDependencies": {
         "@theia/cli": "latest"
     },
@@ -106,6 +101,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-dart-docker/latest.package.json
+++ b/theia-dart-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/navigator": "latest",
@@ -30,13 +29,6 @@
     "devDependencies": {
         "@theia/cli": "latest",
         "@theia/debug": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
@@ -63,6 +55,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-deb-build-docker/package.json
+++ b/theia-deb-build-docker/package.json
@@ -9,7 +9,6 @@
     "dependencies": {
         "@theia/callhierarchy": "latest",
         "@theia/file-search": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/mini-browser": "latest",
@@ -23,13 +22,6 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "scripts": {
         "prebuild-deb": "npm install -g node-deb",

--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -17,7 +17,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/mini-browser": "latest",
@@ -34,13 +33,6 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
@@ -67,6 +59,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -48,7 +48,6 @@
         "@theia/filesystem": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/keymaps": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
@@ -79,10 +78,6 @@
         "The resolution for `fs-extra` was required due to this: https://spectrum.chat/theia/general/our-theia-electron-builder-app-no-longer-starts~f5cf09a0-6d88-448b-8818-24ad0ec2ee7c"
     ],
     "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0",
-        "vscode-languageserver-types": "3.15.0",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0",
         "**/fs-extra": "^4.0.3"
     },
     "theiaPluginsDir": "plugins",
@@ -110,6 +105,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -23,7 +23,6 @@
         "@theia/filesystem": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/keymaps": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
@@ -51,13 +50,6 @@
         "@theia/variable-resolver": "latest",
         "@theia/vsx-registry": "latest",
         "@theia/workspace": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -87,6 +79,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/navigator": "latest",
@@ -56,6 +55,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",
@@ -96,12 +96,5 @@
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
         "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
         "vscode-go": "https://github.com/microsoft/vscode-go/releases/download/0.12.0/Go-0.12.0.vsix"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     }
 }

--- a/theia-java-docker/latest.package.json
+++ b/theia-java-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/navigator": "latest",
@@ -53,6 +52,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",
@@ -95,13 +95,6 @@
         "vscode-java-debug": "https://github.com/microsoft/vscode-java-debug/releases/download/0.24.0/vscjava.vscode-java-debug-0.24.0.vsix",
         "vscode-java-test": "https://github.com/microsoft/vscode-java-test/releases/download/0.22.0/vscjava.vscode-java-test-0.22.0.vsix",
         "vscode-java-dependency-viewer": "https://github.com/microsoft/vscode-java-dependency/releases/download/0.6.0/vscode-java-dependency-0.6.0.vsix"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/theia-php-docker/latest.package.json
+++ b/theia-php-docker/latest.package.json
@@ -20,7 +20,6 @@
         "@theia/filesystem": "latest",
         "@theia/git": "latest",
         "@theia/getting-started": "latest",
-        "@theia/json": "latest",
         "@theia/keymaps": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
@@ -59,6 +58,7 @@
         "vscode-builtin-ini": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/ini-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-markdown": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-1.39.1-prel.vsix",
@@ -85,11 +85,5 @@
         "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
         "vscode-php-intellisense": "https://github.com/felixfbecker/vscode-php-intellisense/releases/download/v2.3.5/php-intellisense.vsix",
         "vscode-php-debug": "https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix"
-    },
-    "resolutions": {
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     }
 }

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/monaco": "latest",
@@ -27,13 +26,6 @@
         "@theia/search-in-workspace": "latest",
         "@theia/terminal": "latest",
         "@theia/vsx-registry": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -63,6 +55,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-rpm-build-docker/package.json
+++ b/theia-rpm-build-docker/package.json
@@ -8,7 +8,6 @@
     "dependencies": {
         "@theia/callhierarchy": "latest",
         "@theia/file-search": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/mini-browser": "latest",
@@ -22,13 +21,6 @@
     },
     "devDependencies": {
         "@theia/cli": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "scripts": {
         "prebuild": "npm install -g yarn",

--- a/theia-ruby-docker/latest.package.json
+++ b/theia-ruby-docker/latest.package.json
@@ -16,7 +16,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/monaco": "latest",
@@ -28,13 +27,6 @@
         "@theia/preferences": "latest",
         "@theia/search-in-workspace": "latest",
         "@theia/terminal": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -64,6 +56,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -16,7 +16,6 @@
         "@theia/file-search": "latest",
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/mini-browser": "latest",
@@ -28,13 +27,6 @@
         "@theia/search-in-workspace": "latest",
         "@theia/terminal": "latest",
         "@theia/vsx-registry": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -64,6 +56,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/editor": "latest",
         "@theia/filesystem": "latest",
         "@theia/git": "latest",
-        "@theia/json": "latest",
         "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/monaco": "latest",
@@ -28,13 +27,6 @@
         "@theia/workspace": "latest",
         "theia-yang-extension": "latest",
         "typescript": "latest"
-    },
-    "resolutions": {
-        "vscode-json-languageserver": "1.2.2",
-        "vscode-languageserver-protocol": "3.15.0-next.9",
-        "vscode-languageserver-types": "3.15.0-next.5",
-        "**/vscode-json-languageserver/**/vscode-languageserver": "6.0.0-next.1",
-        "**/moment": "2.24.0"
     },
     "devDependencies": {
         "@theia/cli": "latest"
@@ -64,6 +56,7 @@
         "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
         "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
         "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
         "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
         "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
         "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: https://github.com/theia-ide/theia-apps/issues/381

The following pull-request updates all **latest** docker images and electron builds to replace the now deprecated `@theia/json` extension with the `vscode-builtin-json-language-features` counterpart.
- remove references of `@theia/json` (next was completed last month https://github.com/theia-ide/theia-apps/pull/380).
- include `vscode-builtin-json-language-features` plugin.
- removed unused `resolutions`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The CI should be successful.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>