### PR TITLE
languages: drop '@theia/languages'

### DIFF
--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -26,7 +26,6 @@
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
         "@theia/keymaps": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/metrics": "latest",

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -26,7 +26,6 @@
         "@theia/getting-started": "next",
         "@theia/git": "next",
         "@theia/keymaps": "next",
-        "@theia/languages": "next",
         "@theia/markers": "next",
         "@theia/messages": "next",
         "@theia/metrics": "next",

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -45,7 +45,6 @@
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
         "@theia/keymaps": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/metrics": "latest",

--- a/theia-electron/package.json
+++ b/theia-electron/package.json
@@ -17,7 +17,7 @@
           "config": {
             "applicationName": "Theia Electron Example Application"
           }
-        }, 
+        },
         "backend": {
             "config": {
                 "startupTimeout": -1
@@ -49,7 +49,6 @@
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
         "@theia/keymaps": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/mini-browser": "latest",

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -24,7 +24,6 @@
         "@theia/getting-started": "latest",
         "@theia/git": "latest",
         "@theia/keymaps": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/metrics": "latest",

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -24,7 +24,6 @@
         "@theia/getting-started": "next",
         "@theia/git": "next",
         "@theia/keymaps": "next",
-        "@theia/languages": "next",
         "@theia/markers": "next",
         "@theia/messages": "next",
         "@theia/metrics": "next",

--- a/theia-php-docker/latest.package.json
+++ b/theia-php-docker/latest.package.json
@@ -21,7 +21,6 @@
         "@theia/git": "latest",
         "@theia/getting-started": "latest",
         "@theia/keymaps": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/messages": "latest",
         "@theia/metrics": "latest",

--- a/theia-php-docker/next.package.json
+++ b/theia-php-docker/next.package.json
@@ -21,7 +21,6 @@
         "@theia/git": "next",
         "@theia/getting-started": "next",
         "@theia/keymaps": "next",
-        "@theia/languages": "next",
         "@theia/markers": "next",
         "@theia/messages": "next",
         "@theia/metrics": "next",

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -16,7 +16,6 @@
         "@theia/git": "next",
         "@theia/getting-started": "next",
         "@theia/keymaps": "next",
-        "@theia/languages": "next",
         "@theia/markers": "next",
         "@theia/messages": "next",
         "@theia/metrics": "next",

--- a/yangster-docker/latest.package.json
+++ b/yangster-docker/latest.package.json
@@ -15,7 +15,6 @@
         "@theia/editor": "latest",
         "@theia/filesystem": "latest",
         "@theia/git": "latest",
-        "@theia/languages": "latest",
         "@theia/markers": "latest",
         "@theia/monaco": "latest",
         "@theia/navigator": "latest",

--- a/yangster-docker/next.package.json
+++ b/yangster-docker/next.package.json
@@ -17,7 +17,6 @@
         "@theia/filesystem": "next",
         "@theia/getting-started": "next",
         "@theia/git": "next",
-        "@theia/languages": "next",
         "@theia/markers": "next",
         "@theia/messages": "next",
         "@theia/monaco": "next",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #387 

The following pull-request removes the deprecated `@theia/languages` extension from both images and apps in favor of using vscode extensions to provide language-support.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that CI passes successfully.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

