### PR TITLE
ext: remove deprecated language extensions

### DIFF
--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -34,7 +34,6 @@
         "@theia/navigator": "latest",
         "@theia/outline-view": "latest",
         "@theia/output": "latest",
-        "@theia/plantuml": "latest",
         "@theia/plugin": "latest",
         "@theia/plugin-ext": "latest",
         "@theia/plugin-ext-vscode": "latest",
@@ -119,6 +118,7 @@
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
         "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix"
     }
 }

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -34,7 +34,6 @@
         "@theia/navigator": "next",
         "@theia/outline-view": "next",
         "@theia/output": "next",
-        "@theia/plantuml": "next",
         "@theia/plugin": "next",
         "@theia/plugin-ext": "next",
         "@theia/plugin-ext-vscode": "next",
@@ -119,6 +118,7 @@
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
         "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix"
     }
 }

--- a/theia-cpp-electron/package.json
+++ b/theia-cpp-electron/package.json
@@ -53,7 +53,6 @@
         "@theia/navigator": "latest",
         "@theia/outline-view": "latest",
         "@theia/output": "latest",
-        "@theia/plantuml": "latest",
         "@theia/plugin": "latest",
         "@theia/plugin-ext": "latest",
         "@theia/plugin-ext-vscode": "latest",
@@ -140,6 +139,7 @@
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
         "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
-        "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix"
+        "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix"
     }
 }

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -216,18 +216,6 @@ RUN apt-get update && apt-get -y install ruby ruby-dev zlib1g-dev && \
     gem install solargraph
 
 
-#Rust
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-
-ENV USER root
-
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y \
-    && rustup update \
-    && rustup component add rls rust-src rust-analysis
-
-
 #Swift
 ARG SWIFT_VERSION=5.2.4
 

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -32,14 +32,12 @@
         "@theia/navigator": "latest",
         "@theia/outline-view": "latest",
         "@theia/output": "latest",
-        "@theia/plantuml": "latest",
         "@theia/plugin": "latest",
         "@theia/plugin-ext": "latest",
         "@theia/plugin-ext-vscode": "latest",
         "@theia/preferences": "latest",
         "@theia/preview": "latest",
         "@theia/process": "latest",
-        "@theia/rust": "latest",
         "@theia/scm": "latest",
         "@theia/search-in-workspace": "latest",
         "@theia/task": "latest",
@@ -134,6 +132,7 @@
         "vscode-ruby": "https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix",
         "vscode-dart": "https://github.com/Dart-Code/Dart-Code/releases/download/v3.8.1/Dart-Code.dart-code-3.8.1.vsix",
         "vscode-flutter": "https://github.com/Dart-Code/Flutter/releases/download/v3.8.1/Dart-Code.flutter-3.8.1.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix",
         "yangster": "https://open-vsx.org/api/typefox/yang-vscode/2.0.3/file/typefox.yang-vscode-2.0.3.vsix"
     }
 }

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -32,15 +32,12 @@
         "@theia/navigator": "next",
         "@theia/outline-view": "next",
         "@theia/output": "next",
-        "@theia/php": "next",
-        "@theia/plantuml": "next",
         "@theia/plugin": "next",
         "@theia/plugin-ext": "next",
         "@theia/plugin-ext-vscode": "next",
         "@theia/preferences": "next",
         "@theia/preview": "next",
         "@theia/process": "next",
-        "@theia/rust": "next",
         "@theia/scm": "next",
         "@theia/search-in-workspace": "next",
         "@theia/task": "next",
@@ -135,6 +132,7 @@
         "vscode-ruby": "https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix",
         "vscode-dart": "https://github.com/Dart-Code/Dart-Code/releases/download/v3.8.1/Dart-Code.dart-code-3.8.1.vsix",
         "vscode-flutter": "https://github.com/Dart-Code/Flutter/releases/download/v3.8.1/Dart-Code.flutter-3.8.1.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix",
         "yangster": "https://open-vsx.org/api/typefox/yang-vscode/2.0.3/file/typefox.yang-vscode-2.0.3.vsix"
     }
 }

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -24,14 +24,12 @@
         "@theia/navigator": "next",
         "@theia/outline-view": "next",
         "@theia/output": "next",
-        "@theia/plantuml": "next",
         "@theia/plugin": "next",
         "@theia/plugin-ext": "next",
         "@theia/plugin-ext-vscode": "next",
         "@theia/preferences": "next",
         "@theia/preview": "next",
         "@theia/process": "next",
-        "@theia/rust": "next",
         "@theia/search-in-workspace": "next",
         "@theia/task": "next",
         "@theia/terminal": "next",
@@ -112,6 +110,7 @@
         "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
         "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
         "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
-        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix"
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "plantuml": "https://open-vsx.org/api/jebbs/plantuml/2.13.12/file/jebbs.plantuml-2.13.12.vsix"
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The following pull-request removes deprecated `@theia` language extensions
and replaces them with vscode counterparts when appropriate.

- removes `@theia/php`.
- removes `@theia/rust`.
- removes `@theia/plantuml` and includes the vscode extension.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify that CI passes successfully.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>