### PR TITLE
Update CMake, dart sdk and go lang.

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -112,9 +112,10 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     ln -s /usr/bin/clangd-$LLVM /usr/bin/clangd
 
 # Install latest stable CMake
-ARG CMAKE_VERSION=3.17.3
+ARG CMAKE_VERSION=3.18.1
 
-RUN wget "https://cmake.org/files/v3.17/cmake-$CMAKE_VERSION-Linux-x86_64.sh" && \
+
+RUN wget "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh" && \
     chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --prefix=/usr/ --skip-license && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update && apt-get -y install git sudo
 #LSPs
 
 ##GO
-ENV GO_VERSION=1.14.4 \
+ENV GO_VERSION=1.15 \
     GOOS=linux \
     GOARCH=amd64 \
     GOROOT=/usr/local/go \
@@ -165,9 +165,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     ln -s /usr/bin/clangd-$LLVM /usr/bin/clangd
 
 # Install latest stable CMake
-ARG CMAKE_VERSION=3.17.3
+ARG CMAKE_VERSION=3.18.1
 
-RUN wget "https://cmake.org/files/v3.17/cmake-$CMAKE_VERSION-Linux-x86_64.sh" && \
+RUN wget "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh" && \
     chmod a+x cmake-$CMAKE_VERSION-Linux-x86_64.sh && \
     ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --prefix=/usr/ --skip-license && \
     rm cmake-$CMAKE_VERSION-Linux-x86_64.sh
@@ -241,7 +241,7 @@ RUN apt-get update \
 
 
 #Dart
-ENV DART_VERSION 2.8.4
+ENV DART_VERSION 2.9.0
 
 RUN \
   apt-get update && apt-get install --no-install-recommends -y -q gnupg2 curl git ca-certificates apt-transport-https openssh-client && \

--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -27,7 +27,7 @@ RUN adduser --disabled-password --gecos '' theia && \
     chown -R theia:theia /home/go-tools;
 USER theia
 
-ENV GO_VERSION=1.14.4 \
+ENV GO_VERSION=1.15 \
     GOOS=linux \
     GOARCH=amd64 \
     GOROOT=/home/go \


### PR DESCRIPTION
Update CMake to latest version 3.18.1, dart sdk to latest version 2.9.0 and go lang to latest version 1.15.

Signed-off-by: Christoph Bayer <chrbayer@criby.de>