### PR TITLE
Added the libraries that are the prerequisites for theia-ide.org

### DIFF
--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=12.18.3
 FROM node:${NODE_VERSION}-alpine
-RUN apk add --no-cache make gcc g++ python
+RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev
 ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json

--- a/theia-php-docker/Dockerfile
+++ b/theia-php-docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=12.18.3
 FROM node:${NODE_VERSION}-alpine
 ARG version=latest
-RUN apk add --no-cache make gcc g++ python
+RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
@@ -28,8 +28,8 @@ RUN apk add --no-cache git openssh bash
 RUN apk add --no-cache curl php php-cli php-mbstring unzip php-openssl php-phar php-json php-tokenizer php-ctype php7-pecl-yaml php7-pecl-xdebug
 RUN sed -i 's/;zend_extension=xdebug.so/zend_extension=xdebug.so/g' /etc/php7/conf.d/xdebug.ini
 RUN echo $'[XDebug]\n\
-xdebug.remote_enable = 1\n\
-xdebug.remote_autostart = 1' >> /etc/php7/conf.d/xdebug.ini
+    xdebug.remote_enable = 1\n\
+    xdebug.remote_autostart = 1' >> /etc/php7/conf.d/xdebug.ini
 RUN curl -s -o composer-setup.php https://getcomposer.org/installer \
     && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
     && rm composer-setup.php


### PR DESCRIPTION
**Problem:**
- Current Dockerfile does not contain the libs that are required in [prerequisites ](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites)section for "[Build your own IDE](https://theia-ide.org/docs/composing_applications/)" section on theia-ide.org.  
- This works fine on localhost, but it gives errors while loading the URL from a remote machine and accessing the VS Code extensions. 

**Steps to Reproduce**
- Build theia docker image with the current docker file and in package.json add the VS Code extensions that are the part of IBM Wazi [workspace](https://www.ibm.com/support/knowledgecenter/SSCH39_1.0.0/wazi/installation_packages.html#installation_packages__code_client). 
- Try to access theia from remote machine and use VS Code extensions.

_Note_: The above problem should be same for mostly all the VS Code extensions that read/write data.

**Solution:**
- After adding the prerequisites the VS Code extensions work fine on remote machine too. 


