### PR TITLE
full: fix python build error

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update \
     && apt-get remove -y software-properties-common \
     && python -m pip install --upgrade pip --user \
     && python3.8 -m pip install --upgrade pip --user \
-    && pip install python-language-server flake8 autopep8
+    && pip3 install python-language-server flake8 autopep8
 
 
 #.NET Core SDK


### PR DESCRIPTION
**Description**

Fixes the recent build error on `theia-full` regarding the python installation:

```
ERROR: Could not find a version that satisfies the requirement ujson>=3.0.0 (from python-language-server) (from versions: 1.4, 1.6, 1.8, 1.9, 1.15, 1.18, 1.19, 1.21, 1.22, 1.23, 1.30, 1.33, 1.34, 1.35, 2.0.0, 2.0.1, 2.0.2, 2.0.3)
ERROR: No matching distribution found for ujson>=3.0.0 (from python-language-server)
The command '/bin/sh -c apt-get update     && apt-get install -y software-properties-common     && add-apt-repository -y ppa:deadsnakes/ppa     && apt-get install -y python-dev python-pip     && apt-get install -y python3.8 python3-dev python3-pip     && apt-get remove -y software-properties-common     && python -m pip install --upgrade pip --user     && python3.8 -m pip install --upgrade pip --user     && pip install python-language-server flake8 autopep8' returned a non-zero code: 1
The command "./build_container.sh $NPM_TAG $IMAGE_NAME $NODE_VERSION $PORT $ENV_VARS" failed and exited with 1 during .
```



Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>