### PR TITLE
[full] Disable .NET SDK Telemetry and .NET welcome message

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -187,6 +187,10 @@ RUN apt-get update \
 
 #.NET Core SDK
 ARG DOTNET_VERSION=3.1
+# disables .NET telemetry
+ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
+# suppresses .NET welcome message
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 
 RUN curl -SLO "https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb" \
     && dpkg -i packages-microsoft-prod.deb \


### PR DESCRIPTION
#### What it does:
+ Fixes #394 
+ Adds environment variables to disable .NET telemetry, .NET welcome message

**Note**: The following message from telemetry will still be in the log. It is a default setting from Microsoft. [See this](https://github.com/dotnet/sdk/issues/8112#issuecomment-294163843)

>Telemetry
>---------
>The .NET Core tools collect usage data in order to help us improve your experience. The data is anonymous and doesn't include command-line arguments. The data is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
Read more about .NET Core CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>