### PR TITLE
full: remove .net message

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -189,8 +189,10 @@ RUN apt-get update \
 ARG DOTNET_VERSION=3.1
 # disables .NET telemetry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
-# suppresses .NET welcome message
+# skips .NET first time experience
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+# supresses .NET welcome
+ENV DOTNET_NOLOGO=true
 
 RUN curl -SLO "https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb" \
     && dpkg -i packages-microsoft-prod.deb \


### PR DESCRIPTION
**Description**

Removes the welcome message for `.NET` based on the [documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/telemetry#disclosure).

> The .NET Core SDK displays text similar to the following when you first run one of the .NET Core CLI commands (for example, dotnet build). Text may vary slightly depending on the version of the SDK you're running. This "first run" experience is how Microsoft notifies you about data collection.

> To disable this message and the .NET Core welcome message, set the DOTNET_NOLOGO environment variable to true. Note that this variable has no effect on telemetry opt out.

**How to Test**

The `.NET` welcome message should not be outputted to the build log:

```
Welcome to .NET Core!
---------------------
Learn more about .NET Core: https://aka.ms/dotnet-docs
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli-docs
Telemetry
---------
The .NET Core tools collect usage data in order to help us improve your experience. The data is anonymous and doesn't include command-line arguments. The data is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
Read more about .NET Core CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
```

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>