### PR TITLE
Revert "[temporary] Disable publish to dockerhub"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_deploy:
 
 deploy:
   provider: script
-  script: "echo 'Publish to dockerhub disabled temporarily'" #docker push "theiaide/$IMAGE_NAME"
+  script: docker push "theiaide/$IMAGE_NAME"
   on:
     branch: master
     condition: $IMAGE_NAME


### PR DESCRIPTION
This reverts commit 31872398ae52dac2c08318f6d30b157baad7dcf9.

After all images we publish have been updated to use two stages,
we are able to re-enable publishing to dockerhub.

The reason for the update is that we realized that build arguments
are saved in the image's history, even if not present in the final
image as such. This means the GH token, used during the build,
was present for anyone to see, in the history of images we were
publishing. The old tokens have been revoked, and from now-on
the Theia app is built in a first stage that's discarded from the
final, published image.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>