### PR TITLE
swift: fix postinstall build error

### DIFF
--- a/theia-swift-docker/Dockerfile
+++ b/theia-swift-docker/Dockerfile
@@ -4,7 +4,7 @@ RUN npm install -g vsce
 RUN git clone --depth 1 https://github.com/apple/sourcekit-lsp
 WORKDIR /sourcekit-lsp/Editors/vscode
 RUN npm install
-RUN npm run postinstall
+RUN npm run vscode:prepublish
 RUN vsce package -o ./sourcekit-lsp.vsix
 
 


### PR DESCRIPTION
**Description**

The following pull-request fixes the `theia-swift-docker` build caused by the missing `postinstall` script for the `sourcekit-lsp` extension: https://github.com/apple/sourcekit-lsp/blob/6511ca732e5957f6ef4f48760e11e7c1643632dc/Editors/vscode/package.json#L23-L28

```json
"scripts": {
    "vscode:prepublish": "npm run compile",
    "compile": "tsc -p ./",
    "watch": "tsc -watch -p ./",
    "createDevPackage": "npm install && ./node_modules/.bin/vsce package -o ./out/sourcekit-lsp-vscode-dev.vsix"
},
``` 

**How to test**
- the CI for the `theia-swift-docker` image should now successfully pass.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>