### PR TITLE
[swift] move to the official swift docker image

### DIFF
--- a/theia-swift-docker/Dockerfile
+++ b/theia-swift-docker/Dockerfile
@@ -26,7 +26,8 @@ RUN yarn --pure-lockfile && \
     yarn cache clean
 
 
-FROM satishbabariya/sourcekit-lsp
+FROM swift
+
 ENV DEBIAN_FRONTEND noninteractive
 ARG NODE_VERSION=12
 ENV NODE_VERSION $NODE_VERSION


### PR DESCRIPTION
previously were using custom images for sourcekit-lsp, now moving to the official swift docker image.