### PR TITLE
Patch: Fix build fails in some images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: ${{ matrix.IMAGE_NAME }}@${{ matrix.NPM_TAG }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -99,4 +99,4 @@ jobs:
       - name: Build
         if: github.event_name != 'pull_request' || steps.check_changed.outputs.status == 'continue'
         shell: bash
-        run: ./build_container.sh ${{ matrix.NPM_TAG }} ${{ matrix.IMAGE_NAME }} ${{ matrix.node }} ${{matrix.PORT}} ${{matrix.ENV_VARS}}
+        run: ./build_container.sh ${{ matrix.NPM_TAG }} ${{ matrix.IMAGE_NAME }} ${{ matrix.node }} ${{ secrets.GITHUB_TOKEN }} ${{matrix.PORT}} ${{matrix.ENV_VARS}}

--- a/build_container.sh
+++ b/build_container.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 set -e
 
-# this script is called by Travis to build the Docker image
+# this script is called by GH workflows to build the Docker image
 NPM_TAG=$1
 IMAGE_NAME=$2
 NODE_VERSION=$3
+GH_TOKEN=$4
 
 # Theia standard port is listening in port 3000 (the common nodejs port), and it is exposed when running the docker
 # container (-p 0.0.0.0:4000:3000). But some new applications may need to change it (e.g. theia-https-docker).
-# This 4th parameter enables to expose a custom port instead of the common 3000 port. It is set to 3000 as a default
+# This 5th parameter enables to expose a custom port instead of the common 3000 port. It is set to 3000 as a default
 # value if not included, for backward compatibility.
-PORT=${4:-3000}
+PORT=${5:-3000}
+shift
 shift
 shift
 shift
 
-# We know that there are at least 3 parameters. If we shift the 4th parameter and it is not set, shift will fail thus
+# We know that there are at least 4 parameters. If we shift the 5th parameter and it is not set, shift will fail thus
 # failing the script (because of set -e)
 [ $# -gt 0 ] && shift
 

--- a/check_changed.sh
+++ b/check_changed.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
-# This script is called by Travis during the install step.
-# It returns 1 if no files where changed. In that case
+# This script is called by GH Workflows before the install step.
+# It echoes 137 if no files where changed. In that case
 # no further building/test is required for this image
 
 IMAGE_NAME=$1

--- a/theia-cpp-docker/latest.package.json
+++ b/theia-cpp-docker/latest.package.json
@@ -53,6 +53,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-cpp-docker/next.package.json
+++ b/theia-cpp-docker/next.package.json
@@ -53,6 +53,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-dart-docker/latest.package.json
+++ b/theia-dart-docker/latest.package.json
@@ -30,6 +30,9 @@
         "@theia/cli": "latest",
         "@theia/debug": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-dart-docker/next.package.json
+++ b/theia-dart-docker/next.package.json
@@ -30,6 +30,9 @@
         "@theia/cli": "next",
         "@theia/debug": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-docker/latest.package.json
+++ b/theia-docker/latest.package.json
@@ -34,6 +34,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-docker/next.package.json
+++ b/theia-docker/next.package.json
@@ -34,6 +34,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-full-docker/latest.package.json
+++ b/theia-full-docker/latest.package.json
@@ -52,6 +52,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-full-docker/next.package.json
+++ b/theia-full-docker/next.package.json
@@ -52,6 +52,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-go-docker/latest.package.json
+++ b/theia-go-docker/latest.package.json
@@ -30,6 +30,9 @@
         "@theia/cli": "latest",
         "@theia/debug": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-go-docker/next.package.json
+++ b/theia-go-docker/next.package.json
@@ -30,6 +30,9 @@
         "@theia/cli": "next",
         "@theia/debug": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-php-docker/latest.package.json
+++ b/theia-php-docker/latest.package.json
@@ -46,6 +46,9 @@
         "@theia/cli": "latest",
         "@theia/debug": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-coffeescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/coffeescript-1.39.1-prel.vsix",

--- a/theia-php-docker/next.package.json
+++ b/theia-php-docker/next.package.json
@@ -46,6 +46,9 @@
         "@theia/cli": "next",
         "@theia/debug": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-coffeescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/coffeescript-1.39.1-prel.vsix",

--- a/theia-python-docker/latest.package.json
+++ b/theia-python-docker/latest.package.json
@@ -30,6 +30,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-python-docker/next.package.json
+++ b/theia-python-docker/next.package.json
@@ -30,6 +30,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-rust-docker/next.package.json
+++ b/theia-rust-docker/next.package.json
@@ -43,6 +43,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "workspaces": [
         "packages/*"
     ],

--- a/theia-swift-docker/latest.package.json
+++ b/theia-swift-docker/latest.package.json
@@ -31,6 +31,9 @@
     "devDependencies": {
         "@theia/cli": "latest"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",

--- a/theia-swift-docker/next.package.json
+++ b/theia-swift-docker/next.package.json
@@ -31,6 +31,9 @@
     "devDependencies": {
         "@theia/cli": "next"
     },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {
         "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",


### PR DESCRIPTION
### What it does
+  The workflow is [failing](https://github.com/theia-ide/theia-apps/actions/runs/398586435) for some images. This PR attempts to address the issue and also fix potential problems by:
	- Change `ubuntu-latest` to `ubuntu-18.04` as the latest version soon will be `20.04`
	- Fix wrongly passing `GITHUB_TOKEN` in `build_container`
	- Fix `node-gyp` error by attempting to call `node-gyp install` first (https://github.com/nodejs/node-gyp/issues/1780#issuecomment-503976718)

### How to test
+ The CI should pass
**Note**: The CI may fail for `rust` images since it's an existing issue with `racer`. This PR doesn't cover the fix for it.

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>