### PR TITLE
[deb] fix image

### DIFF
--- a/theia-deb-build-docker/Dockerfile
+++ b/theia-deb-build-docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 # install development tools
 RUN apt-get update && \
     apt-get install -y curl sudo build-essential jq vim && \
-    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
     apt-get install -y nodejs && \
     npm install -g yarn
 
@@ -28,7 +28,7 @@ RUN npm run build-deb
 FROM ubuntu:bionic
 COPY --from=0 /theia-app/theia-example_0.0.1_all.deb /
 RUN apt-get update && apt-get install -y curl sudo && \
-    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
     apt-get install -y ./theia-example_0.0.1_all.deb && \
     rm theia-example_0.0.1_all.deb
 

--- a/theia-deb-build-docker/package.json
+++ b/theia-deb-build-docker/package.json
@@ -4,7 +4,7 @@
     "license": "EPL-2.0",
     "description": "A custom Theia debian package",
     "engines": {
-        "node": "10.x"
+        "node": "12.x"
     },
     "dependencies": {
         "@theia/callhierarchy": "latest",
@@ -29,7 +29,7 @@
     },
     "node_deb": {
         "init": "none",
-        "dependencies": "nodejs (>= 10.0.0)",
+        "dependencies": "nodejs (>= 12.0.0)",
         "install_strategy": "copy",
         "executable_name": "theia",
         "entrypoints": {


### PR DESCRIPTION
Minimal fix for this image. The example app would need to be updated
to support vscode extensions to be useful.

I was thinking that this may be the only example we have of packaging a 
browser Theia app, along with the `rpm` example. So we may consider 
updating the app, building a `.deb` and using it to install the app in DEBIAN
-based containers. (not in this PR though)

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>