### PR TITLE
CI: Use login-action to log in DockerHub

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,12 +113,12 @@ jobs:
           chromedriver --version
           (cd tests && yarn && yarn test-app-${{ matrix.IMAGE_NAME }})
 
-      - name: Docker login
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
-        env:
-          DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
-          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker deploy
         if: github.event_name != 'pull_request'
@@ -129,3 +129,4 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: docker push "theiaide/${{ matrix.IMAGE_NAME }}"
+


### PR DESCRIPTION
### What it does
Closes #454 
+ Use [login-action](https://github.com/docker/login-action) instead of manually log in to DockerHub (https://github.com/theia-ide/theia-apps/issues/454#issuecomment-764937973).

### How to test
+ Can only test login when the PR is merged to master. It should work if `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` present correctly in the repo secrets (same as [this](https://github.com/DukeNgn/minimal-docker-image/runs/1745457774))

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>