### PR TITLE
CI: Set timeout-minutes per job to 120 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: ${{ matrix.IMAGE_NAME }}@${{ matrix.NPM_TAG }}
     runs-on: ubuntu-18.04
+    timeout_minutes: 60
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What it does
+ Sometimes, the [CI fails and the job stales](https://github.com/theia-ide/theia-apps/actions/runs/516616673) for a long time (6 hours by default). 
+ This PR sets maximum timeout minutes to 120 instead of the default 360. 

### Additional info
+ [GitHub uses 360 as default for `timeout-minutes`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>