### PR TITLE
CI: Fix typo

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: ${{ matrix.IMAGE_NAME }}@${{ matrix.NPM_TAG }}
     runs-on: ubuntu-18.04
-    timeout_minutes: 60
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
+ This commit fixes a typo in the CI-CD workflow file. 
+ [`timeout-minutes`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) is the correct syntax .

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>