### PR TITLE
CI: Define tag when deploy docker images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -129,5 +129,4 @@ jobs:
           retry_wait_seconds: 30
           max_attempts: 3
           retry_on: error
-          command: docker push "theiaide/${{ matrix.IMAGE_NAME }}"
-
+          command: docker push "theiaide/${{ matrix.IMAGE_NAME }}:${{ matrix.NPM_TAG}}"


### PR DESCRIPTION
Fix #465 

+ Specify the image tag (`next` or `latest`) when deploying to DockerHub. This prevents `docker push` to use the default `latest` tag for `next` images
+ The syntax is now following the format `docker push <hub-user>/<repo-name>:<tag>` from [Docker Documentation](https://docs.docker.com/docker-hub/repos/#pushing-a-docker-container-image-to-docker-hub)


Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>