### PR TITLE
CI: Add steps to deploy solid version of the images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -129,4 +129,4 @@ jobs:
           retry_wait_seconds: 30
           max_attempts: 3
           retry_on: error
-          command: docker push "theiaide/${{ matrix.IMAGE_NAME }}:${{ matrix.NPM_TAG}}"
+          command: docker image push --all-tags "theiaide/${{ matrix.IMAGE_NAME }}"

--- a/build_container.sh
+++ b/build_container.sh
@@ -24,10 +24,18 @@ shift
 cd "$IMAGE_NAME-docker"
 
 IMAGE="theiaide/$IMAGE_NAME"
-IMAGE_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
-echo $IMAGE_TAG
+IMAGE_TAG="$IMAGE:$NPM_TAG"
+
 docker build --build-arg "version=$NPM_TAG" --build-arg "NODE_VERSION=$NODE_VERSION" --build-arg "GITHUB_TOKEN=$GH_TOKEN" . -t "$IMAGE_TAG" --no-cache
-docker tag "$IMAGE_TAG" "$IMAGE:$NPM_TAG"
+
+# Tag the image with the solid version if it is `latest`.
+# Then, we have 2 tags refer to the same image, i.e: "theiaide/theia:1.12.1" and "theiaide/theia:latest".
+if [ $NPM_TAG = "latest" ]; then
+    IMAGE_SOLID_TAG="$IMAGE":$(npm view "@theia/core@$NPM_TAG" version)
+    docker tag "$IMAGE_TAG" "$IMAGE_SOLID_TAG"
+fi
+
+docker images "$IMAGE"
 
 # Now we allow to pass extra parameters to the docker run command: any extra parameter to build_container.sh is
 # interpreted as a parameter to docker run (it is useful for e.g. passing environment variables or volume mappings)


### PR DESCRIPTION
- [x] **Reminder**: `check_changes` is temporary bogus for testing. Change it back when ready to merge.

### What it does
This PR adds the ability to tag and deploy a docker image with its solid version.

+ Update `build_container.sh` to only tag images with its solid version when the `NPM_TAG` is `latest`.
+ Add a step in the CI to determine the version and publish with a solid tag.

### Additional info:
+ [push with `--all-tags` option of an image](https://docs.docker.com/engine/reference/commandline/push/#push-all-tags-of-an-image)
+ [`tag` command from docker CLI](https://docs.docker.com/engine/reference/commandline/tag/)

### How to test

+ The CI should pass 
+ Verify in the `build` step of `latest` images, the script successfully tagged the image with a solid version. For example, `theiaide/theia` image should have 2 tags: `1.12.1` and `latest`:
![image](https://user-images.githubusercontent.com/43587865/115436651-3a1ebc00-a1d9-11eb-9f64-7d4fc12c6a8b.png)

+ A minimal repo was set up to test similar use-case:
	- [Successful Action](https://github.com/DukeNgn/minimal-docker-image/runs/2394782633?check_suite_focus=true)
	- [Pushing with `--all-tags` option](https://github.com/DukeNgn/minimal-docker-image/blob/main/.github/workflows/ci-cd.yml#L39-L40)
	- [DockerHub repo shows 2 tags were pushed](https://hub.docker.com/r/dukengn/minimal-docker-image)



Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>