### PR TITLE
[misc images] Add libsecret as build dependency, in addition to runtime dependency

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -61,7 +61,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 FROM common as theia
-
+RUN apt-get update && apt-get -y install libsecret-1-dev
 ARG GITHUB_TOKEN
 # Use "latest" or "next" version for Theia packages
 ARG version=latest
@@ -122,7 +122,7 @@ ARG LLVM=13
 ARG CMAKE_VERSION=3.18.1
 
 RUN apt-get update && \
-    apt-get -y install libsecret-1-dev && \
+    apt-get -y install libsecret-1-0 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=theia /home/theia /home/theia

--- a/theia-dart-docker/Dockerfile
+++ b/theia-dart-docker/Dockerfile
@@ -1,5 +1,6 @@
 ARG NODE_VERSION=12
 FROM node:$NODE_VERSION as theia-builder
+RUN apt-get -qq update && apt-get install -y libsecret-1-dev
 ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
@@ -22,7 +23,7 @@ ARG NODE_VERSION=12
 ENV NODE_VERSION $NODE_VERSION
 
 RUN apt-get -qq update && \
-    apt-get install -y build-essential curl libsecret-1-dev
+    apt-get install -y build-essential curl libsecret-1-0
 
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash
 RUN apt-get install -y nodejs

--- a/theia-docker/Dockerfile
+++ b/theia-docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=12.18.3
 FROM node:${NODE_VERSION}-alpine
-RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev
+RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev libsecret-dev
 ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
@@ -24,7 +24,7 @@ RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
     chown -R theia:theia /home/project;
-RUN apk add --no-cache git openssh bash libsecret-dev
+RUN apk add --no-cache git openssh bash libsecret
 ENV HOME /home/theia
 WORKDIR /home/theia
 COPY --from=0 --chown=theia:theia /home/theia /home/theia

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
                        wget \
                        xz-utils \
                        sudo \
+                       libsecret-1-dev \
     && \
     apt-get clean && \
     apt-get autoremove -y && \
@@ -287,7 +288,7 @@ WORKDIR /home/theia
 
 COPY --from=theia --chown=theia:theia /home/theia /home/theia
 
-RUN apt-get update && apt-get -y install libsecret-1-dev
+RUN apt-get update && apt-get -y install libsecret-1-0
 
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \

--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -2,6 +2,7 @@ ARG NODE_VERSION=12.18.3
 
 FROM node:$NODE_VERSION as theia
 
+RUN apt-get -qq update && apt-get install -y libsecret-1-dev
 ARG GITHUB_TOKEN
 ARG version=latest
 
@@ -22,7 +23,7 @@ RUN yarn --pure-lockfile && \
 FROM node:$NODE_VERSION
 
 RUN apt-get -qq update && \
-    apt-get install -y libsecret-1-dev
+    apt-get install -y libsecret-1-0
 
 COPY --from=theia /home/theia /home/theia
 

--- a/theia-php-docker/Dockerfile
+++ b/theia-php-docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=12.18.3
 FROM node:${NODE_VERSION}-alpine
 ARG version=latest
-RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev
+RUN apk add --no-cache make pkgconfig gcc g++ python libx11-dev libxkbfile-dev libsecret-dev
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
 ARG GITHUB_TOKEN
@@ -24,7 +24,7 @@ RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
     chown -R theia:theia /home/project;
-RUN apk add --no-cache git openssh bash libsecret
+RUN apk add --no-cache git openssh bash -dev libsecret
 RUN apk add --no-cache curl php php-cli php-mbstring unzip php-openssl php-phar php-json php-tokenizer php-ctype php7-pecl-yaml php7-pecl-xdebug
 RUN sed -i 's/;zend_extension=xdebug.so/zend_extension=xdebug.so/g' /etc/php7/conf.d/xdebug.ini
 RUN echo $'[XDebug]\n\

--- a/theia-python-docker/Dockerfile
+++ b/theia-python-docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG NODE_VERSION=12.18.3
 
 FROM node:${NODE_VERSION}
+RUN apt-get update && apt-get install -y libsecret-1-dev
 ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
@@ -37,7 +38,7 @@ RUN apt-get update \
     && rm Python-$VERSION.tgz
 
 RUN apt-get update \
-    && apt-get install -y libsecret-1-dev \
+    && apt-get install -y libsecret-1-0 \
     && apt-get install -y python-dev python-pip \
     && pip install --upgrade pip --user \
     && apt-get install -y python3-dev python3-pip \

--- a/theia-rust-docker/Dockerfile
+++ b/theia-rust-docker/Dockerfile
@@ -7,7 +7,7 @@ ARG NODE_VERSION=12.18.3
 ENV THEIA_RUST_APP_PATH /root/theia_rust_app
 
 RUN apt-get update -yq \
-    && apt-get install curl gnupg build-essential gcc g++ gdb make python sudo git -yq
+    && apt-get install curl gnupg build-essential gcc g++ gdb make python sudo git -yq libsecret-1-dev
 
 # allow a user to become root in the container
 ADD sudoers /etc/sudoers
@@ -35,7 +35,7 @@ RUN . /root/nvm_setup.sh && cd $THEIA_RUST_APP_PATH && yarn --cache-folder $THEI
 FROM common
 
 RUN apt-get update -yq \
-    && apt-get install -y libsecret-1-dev
+    && apt-get install -y libsecret-1-0
 
 COPY --from=theia /root/theia_rust_app /root/theia_rust_app
 

--- a/theia-swift-docker/Dockerfile
+++ b/theia-swift-docker/Dockerfile
@@ -9,6 +9,7 @@ RUN vsce package -o ./sourcekit-lsp.vsix
 
 
 FROM node:$NODE_VERSION as theia-builder
+RUN apt-get update && apt-get install -y build-essential libsecret-1-dev
 ARG version=latest
 WORKDIR /home/theia
 ADD $version.package.json ./package.json
@@ -33,7 +34,7 @@ ARG NODE_VERSION=12
 ENV NODE_VERSION $NODE_VERSION
 RUN apt-get update
 RUN apt-get -qq update
-RUN apt-get install -y build-essential libsecret-1-dev
+RUN apt-get install -y build-essential libsecret-1-0
 RUN apt-get install -y curl
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash
 RUN apt-get install -y nodejs


### PR DESCRIPTION
Adding `libsecret-dev` as a build dependency and switching to the non-dev version of this library for runtime.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>