### PR TITLE
cpp: update `llvm` to 14

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -118,7 +118,7 @@ yarn --cache-folder ./ycache && rm -rf ./ycache && \
 
 FROM common
 
-ARG LLVM=13
+ARG LLVM=14
 ARG CMAKE_VERSION=3.18.1
 
 RUN apt-get update && \

--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -175,7 +175,7 @@ RUN apt-get update && apt-get -y install openjdk-11-jdk maven gradle
 
 # C/C++
 # public LLVM PPA, development version of LLVM
-ARG LLVM=13
+ARG LLVM=14
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \


### PR DESCRIPTION
**What it does**

The commit updates `llvm` to `14` which is the latest bleeding edge.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>