### PR TITLE
ci: enable additional tests

### DIFF
--- a/tests/top-panel/top-panel.ts
+++ b/tests/top-panel/top-panel.ts
@@ -20,97 +20,20 @@ export class TopPanel {
 
     public constructor(protected readonly driver: WebdriverIO.Client<void>) { }
 
+    /**
+     * Determine if the top-panel exists.
+     * @returns `true` if the top-panel exists.
+     */
     exists(): boolean {
         return this.driver.isExisting('div#theia-top-panel');
     }
 
-    openNewTerminal() {
-        this.clickMenuTab('Terminal');
-        this.clickSubMenu('New Terminal');
+    /**
+     * Determine if the menu exists in the top-panel.
+     * @param label the human-readable menu label.
+     */
+    menuExists(label: string): boolean {
+        return this.driver.element('#theia-top-panel').isExisting(`div=${label}`);
     }
 
-    toggleCallHierarchyView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Call Hierarchy');
-    }
-
-    toggleFilesView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Explorer');
-    }
-
-    toggleScmView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Scm');
-    }
-
-    toggleGitHistoryView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Git History');
-    }
-
-    toggleOutlineView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Outline');
-    }
-
-    toggleOutputView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Output');
-    }
-
-    openPluginsView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Plugins');
-    }
-
-    openProblemsView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Problems');
-    }
-
-    toggleSearchView() {
-        this.clickMenuTab('View');
-        this.clickSubMenu('Search');
-    }
-
-    waitForSubMenu(): void {
-        this.driver.waitForExist('div.p-Widget.p-Menu.p-MenuBar-menu');
-    }
-
-    isSubMenuVisible(): boolean {
-        return this.driver.isExisting('div.p-Widget.p-Menu.p-MenuBar-menu');
-    }
-
-    clickMenuTab(tab: number | string) {
-        if (typeof tab === 'string') {
-            this.driver.element('ul.p-MenuBar-content').click(`div=${tab}`);
-        } else {
-            this.driver.click(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tab})`);
-        }
-    }
-
-    clickSubMenu(subMenuItem: string) {
-        this.driver.element('div.p-Widget.p-Menu.p-MenuBar-menu .p-Menu-content').click(`div=${subMenuItem}`);
-    }
-
-    hoverMenuTab(tabNumber: number) {
-        this.driver.moveToObject(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tabNumber})`);
-    }
-
-    isTabActive(tabNumber: number): boolean {
-        return this.driver.isExisting(`ul.p-MenuBar-content > .p-mod-active.p-MenuBar-item:nth-child(${tabNumber}`);
-    }
-
-    isMenuActive(): boolean {
-        return this.driver.isExisting('#theia\\:menubar.p-mod-active');
-    }
-
-    getxBarTabPosition(tabNumber: number) {
-        return this.driver.getLocation(`ul.p-MenuBar-content > .p-MenuBar-item:nth-child(${tabNumber}`, 'x');
-    }
-
-    getxSubMenuPosition(): number {
-        return this.driver.getLocation('div.p-Widget.p-Menu.p-MenuBar-menu', 'x');
-    }
 }

--- a/tests/top-panel/top-panel.ui-spec.ts
+++ b/tests/top-panel/top-panel.ui-spec.ts
@@ -17,14 +17,9 @@
 /* tslint:disable:no-unused-expression*/
 import { expect } from 'chai';
 import { TopPanel } from './top-panel';
-import { BottomPanel } from '../bottom-panel/bottom-panel';
-import { RightPanel } from '../right-panel/right-panel';
-import { LeftPanel } from '../left-panel/left-panel';
 import { MainPage } from '../main-page/main-page';
+
 let topPanel: TopPanel;
-let bottomPanel: BottomPanel;
-let rightPanel: RightPanel;
-let leftPanel: LeftPanel;
 let mainPage: MainPage;
 
 before(() => {
@@ -34,211 +29,54 @@ before(() => {
     driver.url(url);
     driver.localStorage('DELETE');
     driver.refresh();
+
     topPanel = new TopPanel(driver);
-    bottomPanel = new BottomPanel(driver);
-    rightPanel = new RightPanel(driver);
-    leftPanel = new LeftPanel(driver);
     mainPage = new MainPage(driver);
-    // Make sure that the application shell is loaded
+
+    // Make sure that the application shell is loaded.
     mainPage.waitForStartup();
 });
 
-describe('theia top panel (menubar)', () => {
+describe('theia top-panel (menubar)', () => {
+
     it('should show the top panel', () => {
         expect(topPanel.exists()).to.be.true;
     });
 
-    it('should set a menu item active when hovered', () => {
-        topPanel.hoverMenuTab(1);
-        expect(topPanel.isTabActive(1)).to.be.true;
+    describe('top-panel menus', () => {
 
-        topPanel.hoverMenuTab(2);
-        expect(topPanel.isTabActive(1)).to.be.false;
-        expect(topPanel.isTabActive(2)).to.be.true;
-    });
-
-    it('should show menu correctly when clicked on a tab', () => {
-        /* No menu at the start */
-        expect(topPanel.isSubMenuVisible()).to.be.false;
-
-        /* Click on the first child */
-        topPanel.clickMenuTab(1);
-        expect(topPanel.isSubMenuVisible()).to.be.true;
-
-        /* Click again to make the menu disappear */
-        topPanel.clickMenuTab(1);
-        expect(topPanel.isSubMenuVisible()).to.be.false;
-
-        /* Make sure the menu location is directly under the bar tab */
-        topPanel.clickMenuTab(1);
-        let tabX = topPanel.getxBarTabPosition(1);
-        let menuX = topPanel.getxSubMenuPosition();
-        expect(tabX).to.be.equal(menuX);
-
-        /* Test with the second tab by hovering to the second one */
-        topPanel.hoverMenuTab(2);
-        tabX = topPanel.getxBarTabPosition(2);
-        menuX = topPanel.getxSubMenuPosition();
-        expect(tabX).to.be.equal(menuX);
-
-        topPanel.clickMenuTab(2);
-        expect(topPanel.isSubMenuVisible()).to.be.false;
-
-    });
-
-    describe('terminal UI', () => {
-        it('should open a new terminal and then close it', () => {
-            if (!bottomPanel.isTerminalVisible()) {
-                topPanel.openNewTerminal();
-                bottomPanel.waitForTerminal();
-            }
-            expect(bottomPanel.isTerminalVisible()).to.be.true;
-
-            bottomPanel.closeCurrentView();
-            expect(bottomPanel.isTerminalVisible()).to.be.false;
+        it('should show the \'File\' menu', () => {
+            expect(topPanel.menuExists('File')).to.be.true;
         });
-    });
 
-    describe('call hierarchy view UI', () => {
-        it('should start with call hierarchy view not visible', () => {
-            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.false;
+        it('should show the \'Edit\' menu', () => {
+            expect(topPanel.menuExists('Edit')).to.be.true;
         });
-        it('call hierarchy view should toggle-on then toggle-off', () => {
-            if (!bottomPanel.isCallHierarchyViewVisible()) {
-                topPanel.toggleCallHierarchyView();
-                bottomPanel.waitForCallHierarchyView();
-            }
-            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.true;
-            topPanel.toggleCallHierarchyView();
-            expect(bottomPanel.isCallHierarchyViewVisible()).to.be.false;
-        });
-    });
 
-    describe('files view UI', () => {
-        it('should start with files view not visible', () => {
-            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        it('should show the \'Selection\' menu', () => {
+            expect(topPanel.menuExists('Selection')).to.be.true;
         });
-        it('files view should toggle-on then toggle-off', () => {
-            if (!leftPanel.isFileTreeVisible()) {
-                topPanel.toggleFilesView();
-                leftPanel.waitForFilesViewVisible();
-            }
-            expect(leftPanel.isFileTreeVisible()).to.be.true;
-            topPanel.toggleFilesView();
-            expect(leftPanel.isFileTreeVisible()).to.be.false;
-        });
-    });
 
-    describe('scm view UI', () => {
-        // re-enable if/when we reset workbench layout between tests
-        // it('should start with scm view not visible', () => {
-        //     expect(leftPanel.isScmContainerVisible()).to.be.false;
-        // });
-        it('scm view should toggle-on then toggle-off', () => {
-            if (!leftPanel.isScmContainerVisible()) {
-                topPanel.toggleScmView();
-                leftPanel.waitForScmViewVisible();
-            }
-            expect(leftPanel.isScmContainerVisible()).to.be.true;
-            topPanel.toggleScmView();
-            expect(leftPanel.isScmContainerVisible()).to.be.false;
+        it('should show the \'View\' menu', () => {
+            expect(topPanel.menuExists('View')).to.be.true;
         });
-    });
 
-    describe('git history view UI', () => {
-        it('should start with git history view not visible', () => {
-            expect(leftPanel.isGitHistoryContainerVisible()).to.be.false;
+        it('should show the \'Go\' menu', () => {
+            expect(topPanel.menuExists('Go')).to.be.true;
         });
-        it('git history view should toggle-on then toggle-off', () => {
-            if (!leftPanel.isGitHistoryContainerVisible()) {
-                topPanel.toggleGitHistoryView();
-                leftPanel.waitForGitHistoryViewVisible();
-            }
-            expect(leftPanel.isGitHistoryContainerVisible()).to.be.true;
-            topPanel.toggleGitHistoryView();
-            expect(leftPanel.isGitHistoryContainerVisible()).to.be.false;
-        });
-    });
 
-    describe('outline view UI', () => {
-        const tabName = 'Outline';
-        it('should start with outline view tab already created', () => {
-            expect(rightPanel.doesTabExist(tabName)).to.be.true;
+        it('should show the \'Run\' menu', () => {
+            expect(topPanel.menuExists('Run')).to.be.true;
         });
-        it('should start with outline view not visible', () => {
-            expect(rightPanel.isOutlineViewVisible()).to.be.false;
-        });
-        it('should start with outline view tab not active', () => {
-            expect(rightPanel.isTabActive(tabName)).to.be.false;
-        });
-        it('outline view should toggle-on then toggle-off', () => {
-            if (!rightPanel.isOutlineViewVisible()) {
-                topPanel.toggleOutlineView();
-                rightPanel.waitForOutlineViewVisible();
-            }
-            expect(rightPanel.isOutlineViewVisible()).to.be.true;
 
-            topPanel.toggleOutlineView();
-            expect(rightPanel.isOutlineViewVisible()).to.be.false;
+        it('should show the \'Terminal\' menu', () => {
+            expect(topPanel.menuExists('Terminal')).to.be.true;
         });
-    });
 
-    describe('output view UI', () => {
-        it('should start with output view not visible', () => {
-            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        it('should show the \'Help\' menu', () => {
+            expect(topPanel.menuExists('Help')).to.be.true;
         });
-        it('output view should toggle-on then toggle-off', () => {
-            if (!bottomPanel.isOutputViewVisible()) {
-                topPanel.toggleOutputView();
-                bottomPanel.waitForOutputView();
-            }
-            expect(bottomPanel.isOutputViewVisible()).to.be.true;
-            topPanel.toggleOutputView();
-            expect(bottomPanel.isOutputViewVisible()).to.be.false;
-        });
-    });
 
-    describe('plugins view UI', () => {
-        it('should start with plugins view not visible', () => {
-            expect(leftPanel.isFileTreeVisible()).to.be.false;
-        });
-        it('plugins view should toggle-on then toggle-off', () => {
-            if (!bottomPanel.isOutputViewVisible()) {
-                topPanel.toggleOutputView();
-                bottomPanel.waitForOutputView();
-            }
-            expect(bottomPanel.isOutputViewVisible()).to.be.true;
-            topPanel.toggleOutputView();
-            expect(bottomPanel.isOutputViewVisible()).to.be.false;
-        });
-    });
-
-    describe('problems view UI', () => {
-        it('should open a new problems view and then close it', () => {
-            if (!bottomPanel.isProblemsViewVisible()) {
-                topPanel.openProblemsView();
-                bottomPanel.waitForProblemsView();
-            }
-            expect(bottomPanel.isProblemsViewVisible()).to.be.true;
-
-            bottomPanel.closeCurrentView();
-            expect(bottomPanel.isProblemsViewVisible()).to.be.false;
-        });
-    });
-
-    describe('search view UI', () => {
-        it('should start with search view visible', () => {
-            expect(leftPanel.isSearchViewVisible()).to.be.true;
-        });
-        it('search view should toggle-on then toggle-off', () => {
-            if (!leftPanel.isSearchViewVisible()) {
-                topPanel.toggleSearchView();
-                leftPanel.waitForSearchViewVisible();
-            }
-            expect(leftPanel.isSearchViewVisible()).to.be.true;
-            topPanel.toggleSearchView();
-            expect(leftPanel.isSearchViewVisible()).to.be.false;
-        });
     });
 
 });

--- a/tests/wdio.base.conf.js
+++ b/tests/wdio.base.conf.js
@@ -85,7 +85,7 @@ function makeConfig(headless) {
 
         // this is a very basic test suite that should work on all our Theia applications. 
         specs: [
-            './main-page/main-page.ui-spec.ts'
+            './**/*spec.ts'
         ],
         // Patterns to exclude.
         exclude: [
@@ -135,7 +135,7 @@ function makeConfig(headless) {
         sync: true,
         //
         // Level of logging verbosity: silent | verbose | command | data | result | error
-        logLevel: 'result',
+        logLevel: 'error',
         //
         // Enables colors for log output.
         coloredLogs: true,


### PR DESCRIPTION
**What it does**

The pull-request enables additional tests for docker images which were otherwise not executed.
The `top-panel` tests were simplified and should now cover cases where the top-panel is visible but no menus are present, and should hopefully help identify issues like https://github.com/theia-ide/theia-apps/issues/494.

The following images are expected to fail:
- `theia-cpp-docker` due to https://github.com/theia-ide/theia-apps/issues/494
- `theia-full-docker` due to https://github.com/theia-ide/theia-apps/issues/494

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>