### PR TITLE
Removed images from CI, Disabled Docker Hub publish, added README note

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,45 +25,8 @@ jobs:
         NPM_TAG: ["latest", "next"]
         IMAGE_NAME:
           [
-            "theia",
-            "theia-cpp",
             "theia-full",
-            "theia-go",
-            "theia-https",
-            "theia-php",
-            "theia-python",
           ]
-        include:
-          - IMAGE_NAME: "theia-https"
-            ENV_VARS: "-e token="
-            PORT: 10443
-
-          # `dart` images use node 12 for building.
-          - IMAGE_NAME: "theia-dart"
-            NPM_TAG: "latest"
-            node_test: 10
-            node: 12
-
-          - IMAGE_NAME: "theia-dart"
-            NPM_TAG: "next"
-            node_test: 10
-            node: 12
-
-          - IMAGE_NAME: "theia-rust"
-            NPM_TAG: "next"
-            node_test: 10
-            node: 12.18.3
-
-          # `swift` images use node 12 for building.
-          - IMAGE_NAME: "theia-swift"
-            NPM_TAG: "latest"
-            node_test: 10
-            node: 12
-
-          - IMAGE_NAME: "theia-swift"
-            NPM_TAG: "next"
-            node_test: 10
-            node: 12
 
     steps:
       - name: Checkout
@@ -113,20 +76,3 @@ jobs:
           google-chrome --version
           chromedriver --version
           (cd tests && yarn && yarn test-app-${{ matrix.IMAGE_NAME }})
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        if: github.event_name != 'pull_request'
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker deploy
-        if: github.event_name != 'pull_request'
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          retry_wait_seconds: 30
-          max_attempts: 3
-          retry_on: error
-          command: docker image push --all-tags "theiaide/${{ matrix.IMAGE_NAME }}"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Collection of example cloud & desktop applications built using the [Theia](https
 
 <br />
 
+__Note: This repository is soon to be considered deprecated and will eventually be archived. [Theia Blueprint](https://github.com/eclipse-theia/theia-blueprint) is a more polished example application based on the Eclipse Theia framework, that might be of interest. For more details, see issue [#496](https://github.com/theia-ide/theia-apps/issues/496).__
+
+<br />
+
 ### Outline
 
 - [Overview](#overview)


### PR DESCRIPTION
This commit removes all images from CI except theia-full,
disables publishing to Docker Hub and adds a note to root
README. These are the first steps of the repo's ramp-down,
as documented in :
https://github.com/theia-ide/theia-apps/issues/496

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>