### PR TITLE
Fixed missing gcc 10 dependencies

### DIFF
--- a/theia-cpp-docker/Dockerfile
+++ b/theia-cpp-docker/Dockerfile
@@ -130,6 +130,12 @@ WORKDIR /home/theia
 
 # C/C++ Developer tools
 
+# gcc 10 repository
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get remove -y software-properties-common
+
 # Install clangd and clang-tidy from the public LLVM PPA (nightly build / development version)
 # And also the GDB debugger from the Ubuntu repos
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \


### PR DESCRIPTION
LLVM 14 relies on GCC 10 related packages which are now missing from Ubuntu 18.04