### PR TITLE
go: fix build issues caused by golang

### DIFF
--- a/theia-full-docker/Dockerfile
+++ b/theia-full-docker/Dockerfile
@@ -127,46 +127,28 @@ FROM common
 
 # LSPs
 
-## GO
-ENV GO_VERSION=1.15 \
+## Go
+ENV GO_VERSION=1.17.3 \
     GOOS=linux \
     GOARCH=amd64 \
     GOROOT=/usr/local/go \
     GOPATH=/usr/local/go-packages
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 # Install Go
+# https://go.dev/doc/install
 RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.$GOOS-$GOARCH.tar.gz | tar -C /usr/local -xzv
 
-# Install VS Code Go tools: https://github.com/Microsoft/vscode-go/blob/058eccf17f1b0eebd607581591828531d768b98e/src/goInstallTools.ts#L19-L45
-RUN go get -u -v github.com/mdempsky/gocode && \
-    go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs && \
+# VS Code Go Tools https://github.com/golang/vscode-go/blob/master/docs/tools.md
+RUN go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs@v2 && \
     go get -u -v github.com/ramya-rao-a/go-outline && \
-    go get -u -v github.com/acroca/go-symbols && \
-    go get -u -v golang.org/x/tools/cmd/guru && \
-    go get -u -v golang.org/x/tools/cmd/gorename && \
+    go get -u -v github.com/cweill/gotests/gotests && \
     go get -u -v github.com/fatih/gomodifytags && \
-    go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
     go get -u -v github.com/josharian/impl && \
-    go get -u -v github.com/tylerb/gotype-live && \
-    go get -u -v github.com/rogpeppe/godef && \
-    go get -u -v github.com/zmb3/gogetdoc && \
-    go get -u -v golang.org/x/tools/cmd/goimports && \
-    go get -u -v github.com/sqs/goreturns && \
-    go get -u -v winterdrache.de/goformat/goformat && \
-    go get -u -v golang.org/x/lint/golint && \
-    go get -u -v github.com/cweill/gotests/... && \
-    go get -u -v github.com/alecthomas/gometalinter && \
-    go get -u -v honnef.co/go/tools/... && \
-    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint && \
-    go get -u -v github.com/mgechev/revive && \
-    go get -u -v github.com/sourcegraph/go-langserver && \
+    go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
     go get -u -v github.com/go-delve/delve/cmd/dlv && \
-    go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct && \
-    go get -u -v github.com/godoctor/godoctor
-
-RUN go get -u -v -d github.com/stamblerre/gocode && \
-    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode
+    GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint && \
+                   go get -u -v golang.org/x/tools/gopls@v0.7.3
 
 ENV PATH=$PATH:$GOPATH/bin
 
@@ -176,6 +158,11 @@ RUN apt-get update && apt-get -y install openjdk-11-jdk maven gradle
 # C/C++
 # public LLVM PPA, development version of LLVM
 ARG LLVM=14
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get remove -y software-properties-common
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/llvm.list && \

--- a/theia-go-docker/Dockerfile
+++ b/theia-go-docker/Dockerfile
@@ -42,45 +42,28 @@ RUN adduser --disabled-password --gecos '' theia && \
 
 USER theia
 
-ENV GO_VERSION=1.15 \
+## Go
+ENV GO_VERSION=1.17.3 \
     GOOS=linux \
     GOARCH=amd64 \
-    GOROOT=/home/go \
-    GOPATH=/home/go-tools
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+    GOROOT=/usr/local/go \
+    GOPATH=/usr/local/go-packages
+ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 # Install Go
-RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.$GOOS-$GOARCH.tar.gz | tar -C /home -xzv
+# https://go.dev/doc/install
+RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.$GOOS-$GOARCH.tar.gz | tar -C /usr/local -xzv
 
-# Install VS Code Go tools: https://github.com/Microsoft/vscode-go/blob/058eccf17f1b0eebd607581591828531d768b98e/src/goInstallTools.ts#L19-L45
-RUN go get -u -v github.com/mdempsky/gocode && \
-    go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs && \
+# VS Code Go Tools https://github.com/golang/vscode-go/blob/master/docs/tools.md
+RUN go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs@v2 && \
     go get -u -v github.com/ramya-rao-a/go-outline && \
-    go get -u -v github.com/acroca/go-symbols && \
-    go get -u -v golang.org/x/tools/cmd/guru && \
-    go get -u -v golang.org/x/tools/cmd/gorename && \
+    go get -u -v github.com/cweill/gotests/gotests && \
     go get -u -v github.com/fatih/gomodifytags && \
-    go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
     go get -u -v github.com/josharian/impl && \
-    go get -u -v github.com/tylerb/gotype-live && \
-    go get -u -v github.com/rogpeppe/godef && \
-    go get -u -v github.com/zmb3/gogetdoc && \
-    go get -u -v golang.org/x/tools/cmd/goimports && \
-    go get -u -v github.com/sqs/goreturns && \
-    go get -u -v winterdrache.de/goformat/goformat && \
-    go get -u -v golang.org/x/lint/golint && \
-    go get -u -v github.com/cweill/gotests/... && \
-    go get -u -v github.com/alecthomas/gometalinter && \
-    go get -u -v honnef.co/go/tools/... && \
-    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint && \
-    go get -u -v github.com/mgechev/revive && \
-    go get -u -v github.com/sourcegraph/go-langserver && \
+    go get -u -v github.com/haya14busa/goplay/cmd/goplay && \
     go get -u -v github.com/go-delve/delve/cmd/dlv && \
-    go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct && \
-    go get -u -v github.com/godoctor/godoctor
-
-RUN go get -u -v -d github.com/stamblerre/gocode && \
-    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode
+    GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint && \
+                   go get -u -v golang.org/x/tools/gopls@v0.7.3
 
 # Configure Theia
 ENV SHELL=/bin/bash \


### PR DESCRIPTION
**Description**

Fixes: #505 

The commit fixes `go` issues related to an incompatible go version with the declared modules, and adjusts the go-tools for newer go versions.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>